### PR TITLE
Use goutte driver by default

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -1,10 +1,12 @@
 default:
-  context:
-    class: Claroline\CoreBundle\Tests\Integration\Context\FeatureContext
-  extensions:
-    Behat\MinkExtension\Extension:
-      base_url: http://localhost/claroline-behat/web/app.php/
-      default_session: selenium2
-      selenium2: ~
-      show_cmd: firefox %s
-    Behat\Symfony2Extension\Extension: ~
+    context:
+        class: Claroline\CoreBundle\Tests\Integration\Context\FeatureContext
+    extensions:
+        Behat\MinkExtension\Extension:
+            base_url: http://localhost/claroline-behat/web/app.php/
+            default_session: goutte
+            javascript_session: selenium2
+            selenium2: ~
+            goutte: ~
+            show_cmd: firefox %s
+        Behat\Symfony2Extension\Extension: ~

--- a/composer.dist.json
+++ b/composer.dist.json
@@ -29,6 +29,7 @@
         "mikey179/vfsStream": "dev-master",
         "behat/mink-bundle": "dev-master",
         "behat/mink-selenium2-driver": "*",
+        "behat/mink-goutte-driver": "1.0.*",
         "phpunit/phpunit": "3.7.*",
         "behat/behat": "*",
         "behat/symfony2-extension": "*",


### PR DESCRIPTION
Using headless driver is faster than using a non-headless driver when javascript execution is not needed.

In that case when we want to test javascript in a scenario we have to put the `@javascript` tag on it.
