### PR TITLE
Configure env and debug parameter for Symfony2 behat extension

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -9,4 +9,8 @@ default:
             selenium2: ~
             goutte: ~
             show_cmd: firefox %s
-        Behat\Symfony2Extension\Extension: ~
+        Behat\Symfony2Extension\Extension:
+            mink_driver: true
+            kernel:
+                env: test
+                debug: true


### PR DESCRIPTION
It allows us to choose the database to use for the test, test by default.
