### PR TITLE
Deactivate deprecated

### DIFF
--- a/app/console
+++ b/app/console
@@ -19,7 +19,7 @@ $env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?:
 $debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(array('--no-debug', '')) && $env !== 'prod';
 
 if ($debug) {
-    Debug::enable();
+    Debug::enable(E_ALL ^ ~E_DEPRECATED);
 }
 
 $kernel = new AppKernel($env, $debug);


### PR DESCRIPTION
As with Symfony 2.7 there are a lot of deprecated to prepare the 3.0 version we see a lot of deprecated when executing the console script.
This update remove the display of the deprecated.