### PR TITLE
Remove erroneous report flag + fix version check

### DIFF
--- a/app/console
+++ b/app/console
@@ -19,7 +19,7 @@ $env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?:
 $debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(array('--no-debug', '')) && $env !== 'prod';
 
 if ($debug) {
-    Debug::enable(E_ALL ^ ~E_DEPRECATED);
+    Debug::enable();
 }
 
 $kernel = new AppKernel($env, $debug);

--- a/scripts/check.php
+++ b/scripts/check.php
@@ -47,8 +47,11 @@ function ensureVersion($executable, $versionCmd, $minExpected)
     }
 
     $expected = explode('.', $minExpected);
+    $isUnderMajor = $matches[1] < $expected[0];
+    $hasSameMajor = $matches[1] === $expected[0];
+    $isUnderMinor = $matches[2] < $expected[1];
 
-    if ($matches[1] < $expected[0] || $matches[2] < $expected[1]) {
+    if ($isUnderMajor || $hasSameMajor && $isUnderMinor) {
         abort(sprintf(
             'Expected %s >= %s, found %s.%s',
             $executable,

--- a/web/app.php
+++ b/web/app.php
@@ -15,17 +15,18 @@ require_once __DIR__.'/../app/AppKernel.php';
 
 use Symfony\Component\Yaml\Yaml;
 
-$maintenanceMode = file_exists(__DIR__ . '/../app/config/.update');
+$maintenanceMode = file_exists(__DIR__.'/../app/config/.update');
 $authorized = false;
 
-if (file_exists($file = __DIR__ . '/../app/config/ip_white_list.yml')) {
-
+if (file_exists($file = __DIR__.'/../app/config/ip_white_list.yml')) {
     $ips = Yaml::parse($file);
     $authorized = false;
 
     if (is_array($ips)) {
         foreach ($ips as $ip) {
-            if ($ip === $_SERVER['REMOTE_ADDR']) $authorized = true;
+            if ($ip === $_SERVER['REMOTE_ADDR']) {
+                $authorized = true;
+            }
         }
     }
 }
@@ -37,6 +38,6 @@ if (!$maintenanceMode || $authorized) {
     $kernel->handle($request)->send();
     //$kernel->terminate($request, $response);
 } else {
-    $url = $_SERVER['HTTP_HOST'] . $_SERVER['SCRIPT_NAME'] . '/../maintenance.php';
+    $url = $_SERVER['HTTP_HOST'].$_SERVER['SCRIPT_NAME'].'/../maintenance.php';
     header("Location: http://{$url}");
 }

--- a/web/maintenance.php
+++ b/web/maintenance.php
@@ -1,9 +1,9 @@
 <?php
 
-$maintenanceMode = file_exists(__DIR__ . '/../app/config/.update');
+$maintenanceMode = file_exists(__DIR__.'/../app/config/.update');
 
 if (!$maintenanceMode) {
-    $url = $_SERVER['HTTP_HOST'] . $_SERVER['SCRIPT_NAME'] . '/../app.php';
+    $url = $_SERVER['HTTP_HOST'].$_SERVER['SCRIPT_NAME'].'/../app.php';
     header("Location: http://{$url}");
 }
 


### PR DESCRIPTION
The following error reporting flag in app/console is incorrect:

`Debug::enable(E_ALL ^ ~E_DEPRECATED);`

The result is that sometimes php crashes silently instead of throwing fatal errors...

The correct form would be `E_ALL & ~E_DEPRECATED` but it doesn't look like deprecation messages should be removed at all from the dev environment, so I left it on its default value (`E_ALL`).

This PR also fixes a logic error in scripts/check.php and applies php-cs fixes coming from claroline/Distribution.