### PR TITLE
Replace module commands by explicit/absolute paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "description": "Claroline dev dependencies and scripts",
   "scripts": {
-    "bower": "bower update --allow-root",
+    "bower": "node_modules/bower/bin/bower update --allow-root",
     "themes": "node vendor/claroline/distribution/main/core/Resources/scripts/build-themes",
-    "webpack": "rm -rf web/dist/* && webpack --progress --profile --colors --display-error-details",
-    "watch": "webpack-dev-server --hot --inline --content-base web --claro-tgt=watch --display-error-details"
+    "webpack": "rm -rf web/dist/* && node_modules/webpack/bin/webpack.js --progress --profile --colors --display-error-details",
+    "watch": "node_modules/webpack-dev-server/bin/webpack-dev-server.js --hot --inline --content-base web --claro-tgt=watch --display-error-details"
   },
   "dependencies": {
     "claroline-core": "file:./vendor/claroline/distribution"


### PR DESCRIPTION
For some reason, executing node commands in npm scripts sometimes leads to path errors: https://travis-ci.org/claroline/Distribution/builds/129947034#L425. 