### PR TITLE
bin/ location

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "fast-install" : [
             "php scripts/check.php",
             "php app/console doctrine:database:create --if-not-exists",
-            "php bin/doctrine dbal:import claroline.sql -vvv",
+            "php bin/vendor/doctrine dbal:import claroline.sql -vvv",
             "php app/console assets:install web --symlink"
         ],
         "sync": [
@@ -78,7 +78,6 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
-        "bin-dir": "bin",
         "github-protocols": ["https", "git", "ssh"],
         "process-timeout": 3600
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "fast-install" : [
             "php scripts/check.php",
             "php app/console doctrine:database:create --if-not-exists",
-            "php bin/vendor/doctrine dbal:import claroline.sql -vvv",
+            "php vendor/bin/doctrine dbal:import claroline.sql -vvv",
             "php app/console assets:install web --symlink"
         ],
         "sync": [


### PR DESCRIPTION
Move the bin/ folder back into vendor/ so that it can be cached by travis.claroline.com and so that when building a docker image from a travis PR, the build folder is present.