### PR TITLE
Permissions changes crash composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,8 @@
     "prefer-stable": true,
     "config": {
         "github-protocols": ["https", "git", "ssh"],
-        "process-timeout": 3600
+        "process-timeout": 3600,
+        "discard-changes": true
     },
     "extra": {
         "symfony-app-dir": "app",


### PR DESCRIPTION
it's not meant to be merged but it's a pretext to discuss an update after some permissions editions on the project.

Editing perms will trigger composer notifications (discard, cancel, ...) on `composer update` and crash the script on `composer install`.
Do we plan to support this use case or not ?

If yes, this pr is pretty much the only way to achieve a coherent result afaik.