### PR TITLE
Removing fast-install check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     },
     "scripts": {
         "fast-install" : [
-            "php scripts/check.php",
             "php app/console doctrine:database:create --if-not-exists",
             "php vendor/bin/doctrine dbal:import claroline.sql -vvv",
             "php app/console assets:install web --symlink"


### PR DESCRIPTION
We don't run npm/node here so no point checking and crashing if it's not installed.