### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
     "claroline-core": "./vendor/claroline/distribution"
   },
   "resolutions": {
-    "angular": ">=1.4.0"
+    "angular": ">=1.4.0",
+    "jquery": "2.2.0"
   }
 }


### PR DESCRIPTION
This is required by the chat bundle for travis.
The chat requires the strophejs library wich will resolves the jquery version at 1.11.0... but it works fine with jquery 2.2.0 aswell.