### PR TITLE
Move distribution dev dependencies to project root

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,50 @@
 {
   "name": "claroline",
   "version": "1.0.0",
-  "description": "Claroline dev dependencies and scripts",
+  "description": "Claroline front/dev dependencies and scripts",
   "scripts": {
     "bower": "node_modules/bower/bin/bower update --allow-root",
     "themes": "node vendor/claroline/distribution/main/core/Resources/scripts/build-themes",
     "uglify": "for f in web/dist/*.js; do echo \"Uglifying ${f}...\" && ./node_modules/.bin/uglifyjs $f -o $f; done",
-    "webpack": "export NODE_ENV=production  && rm -rf web/dist/* && node_modules/webpack/bin/webpack.js --progress --profile --colors --display-error-details && npm run uglify",
-    "watch": "node_modules/webpack-dev-server/bin/webpack-dev-server.js --hot --inline --content-base web --claro-tgt=watch --display-error-details",
+    "dll": "node_modules/webpack/bin/webpack.js --config=vendor/claroline/distribution/webpack.dll.js --progress --colors --display-error-details",
+    "webpack": "export NODE_ENV=production && rm -rf web/dist/* && npm run dll && node_modules/webpack/bin/webpack.js  --json --config=vendor/claroline/distribution/webpack.prod.js --progress --colors --display-error-details > webpack-stats.json && npm run uglify",
+    "watch": "npm run dll && node_modules/webpack-dev-server/bin/webpack-dev-server.js --hot  --config=vendor/claroline/distribution/webpack.dev.js --inline --content-base web --claro-tgt=watch --display-error-details",
     "karma": "node_modules/.bin/karma start vendor/claroline/distribution/karma.conf.js"
   },
   "dependencies": {
     "claroline-core": "file:./vendor/claroline/distribution"
+  },
+  "devDependencies": {
+    "assets-webpack-plugin": "^3.4.0",
+    "autoprefixer": "^6.3.1",
+    "babel-core": "^6.5.1",
+    "babel-loader": "^6.2.2",
+    "babel-plugin-transform-runtime": "^6.5.0",
+    "babel-preset-es2015": "^6.5.0",
+    "babel-preset-react": "^6.11.1",
+    "bower": "^1.7.7",
+    "colors": "^1.1.2",
+    "css-loader": "^0.25.0",
+    "cssnano": "^3.4.0",
+    "eslint": "^2.13.1",
+    "file-loader": "^0.9.0",
+    "filesystem-bower-resolver": "^1.2.0",
+    "imports-loader": "^0.6.5",
+    "karma": "^0.13.22",
+    "karma-chrome-launcher": "^1.0.1",
+    "karma-mocha": "^1.0.1",
+    "karma-webpack": "^1.7.0",
+    "less": "^2.5.3",
+    "mocha": "^2.5.3",
+    "postcss-cli": "^2.5.0",
+    "raw-loader": "^0.5.1",
+    "redux-mock-store": "^1.1.4",
+    "shelljs": "^0.5.3",
+    "style-loader": "^0.13.1",
+    "uglify-js": "^2.6.2",
+    "url-loader": "^0.5.7",
+    "webpack": "^1.12.13",
+    "webpack-dev-server": "^1.14.1",
+    "webpack-fail-plugin": "^1.0.4"
   }
 }


### PR DESCRIPTION
Treat second point of claroline/Distribution#1009:

- dev deps are here (npm is like composer, it doesn't install dev deps recursively so they must be in the project root)
- regular/front/app deps stay in the distribution