### PR TITLE
adds missing webpack plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.11.1",
     "bower": "^1.7.7",
+    "circular-dependency-plugin": "^2.0.0",
     "colors": "^1.1.2",
     "css-loader": "^0.25.0",
     "cssnano": "^3.4.0",


### PR DESCRIPTION
In the last `master`, I'm not able to run webpack due to a missing plugin `CircularDependencyPlugin`.
I don't know why it worked before as I can't see any reference to this package in previous versions (maybe it was a dependency of a dependency that have been removed ?).

Is it ok for you @stefk ?