### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "claroline/distribution": "12.x-dev"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "2.11",
+        "friendsofphp/php-cs-fixer": "2.14",
         "mockery/mockery": "0.9.6",
         "mikey179/vfsStream": "1.6.4",
         "phpmd/phpmd": "@stable",


### PR DESCRIPTION
Je ne sais pas si c'est une bonne idée mais la v2.11 n'est pas compatible avec php > 7.3.
Je suis en train de refaire une install propre et mon php est en 7.3.2.