### PR TITLE
changes travis build env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
 
 services:
   - xvfb
+  - mysql
 
 before_install:
   - phpenv config-rm xdebug.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ before_install:
   # prepare execution of chromium in js tests
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 
 before_script:
   - composer validate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: precise
 language: php
 
 php:
@@ -6,6 +5,9 @@ php:
 
 env:
   - DB=mysql
+
+services:
+  - xvfb
 
 before_install:
   - phpenv config-rm xdebug.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - "7.1"
+  - "7.2"
 
 env:
   - DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 before_script:
   # add swap
   - sudo swapon -s
-  - sudo fallocate -l 4G /swapfile
+  - sudo fallocate -l 8G /swapfile
   - sudo chmod 600 /swapfile
   - sudo mkswap /swapfile
   - sudo swapon /swapfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,14 @@ before_install:
   - export DISPLAY=:99.0
 
 before_script:
+  # add swap
+  - sudo swapon -s
+  - sudo fallocate -l 4G /swapfile
+  - sudo chmod 600 /swapfile
+  - sudo mkswap /swapfile
+  - sudo swapon /swapfile
+  - sudo swapon -s
+  
   - composer validate
   - php scripts/configure.php --default
   - composer sync-dev


### PR DESCRIPTION
Travis n'utilise pas le même environnement de build que Distribution (je ne sais pas pourquoi) et l'environnement utilisé ne sera bientôt plus supporté par travis.

> This job ran on our Precise environment, which is in the process of being decommissioned. Please update to a newer Ubuntu version by specifying dist: xenial in your .travis.yml.