### PR TITLE
Update docker-compose config

### DIFF
--- a/.docker/mysql/my.cnf
+++ b/.docker/mysql/my.cnf
@@ -1,3 +1,0 @@
-[mysqld]
-
-sql_mode = ""

--- a/.docker/web/Dockerfile
+++ b/.docker/web/Dockerfile
@@ -1,7 +1,8 @@
-FROM php:7.0.7-apache
+FROM php:7.1.0-apache
 
 MAINTAINER Donovan Tengblad
 
+RUN curl -sL https://deb.nodesource.com/setup_13.x | bash
 RUN a2enmod rewrite expires ssl headers
 
 RUN apt-get update && apt-get install -y \
@@ -25,7 +26,7 @@ RUN apt-get update && apt-get install -y \
   g++ \
   ssl-cert \
   curl \
-  npm \
+  nodejs\
   && rm -rf /var/lib/apt/lists/*
 
 RUN docker-php-ext-install -j$(nproc) xml mcrypt mysqli curl zip mbstring gettext pdo_mysql gd exif mbstring
@@ -33,14 +34,10 @@ RUN docker-php-ext-configure intl
 RUN docker-php-ext-install intl
 RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ && docker-php-ext-install ldap
 
-RUN npm cache clean -f \
-    && npm install -g n \
-    && n 5.11.1
-
 RUN curl -sS https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer
 
-RUN wget http://download.gna.org/wkhtmltopdf/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz
+RUN wget http://downloads.wkhtmltopdf.org/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz
 RUN tar -xf wkhtmltox-0.12.3_linux-generic-amd64.tar.xz
 
 RUN mv wkhtmltox/bin/wkhtmltopdf /usr/bin/wkhtmltopdf.sh

--- a/.docker/web/entrypoint.sh
+++ b/.docker/web/entrypoint.sh
@@ -2,8 +2,10 @@
 
 set -e
 
+
 # Wait for MySQL to respond, depends on mysql-client
-while ! mysqladmin ping -h"$DB_HOST" --silent; do
+echo "Waiting for $DB_HOST..."
+while ! mysqladmin ping -h "$DB_HOST" --silent; do
     echo "MySQL is down"
     sleep 1
 done

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.14",
         "mockery/mockery": "0.9.9",
-        "mikey179/vfsStream": "1.6.4",
+        "mikey179/vfsstream": "1.6.4",
         "phpmd/phpmd": "@stable",
         "phpunit/phpunit": "7.1.5",
         "symfony/phpunit-bridge": "4.0.9",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,5 +2,43 @@ version: '2'
 services:
   web:
     build: .docker/web/
+    ports:
+       - "80:80"
     volumes:
       - .:/var/www/html/claroline # This is where the symfony files are stored
+    environment:
+      APP_URL: caroline.exemple.com
+      ENV: PROD
+      DB_HOST: claroline_db_1
+      DB_NAME: claroline
+      DB_USER: claroline
+      DB_PASSWORD: claroline
+      SECRET: 'secret-claroline'
+      ADMIN_FIRSTNAME: John
+      ADMIN_LASTNAME: Doe
+      ADMIN_USERNAME: root
+      ADMIN_PASSWORD: claroline
+      ADMIN_EMAIL: claroline@example.com
+    networks:
+       app_net_caro:
+         ipv4_address: 172.22.9.6
+  db:
+    environment:
+      MYSQL_ROOT_PASSWORD: claroline
+      MYSQL_USER: claroline
+      MYSQL_PASSWORD: claroline
+      MYSQL_DATABASE: claroline
+    image: mysql:5.6
+    ports:
+       - "3306:3306"
+    volumes:
+      - ./mysql_data:/var/lib/mysql
+    networks:
+       app_net_caro:
+         ipv4_address: 172.22.9.5
+networks:
+  app_net_caro:
+    ipam:
+      driver: bridge
+      config:
+       - subnet: 172.22.9.0/24


### PR DESCRIPTION
I'm trying to run Claroline in a Docker image using your `docker-compose.yml` file. It doesn't seem up-to-date so I change it a bit. With those changes (and maybe changing some `git:` to `https:` in some vendored `packages.json`, probably in `vendor/claroline/distribution` which is not versioned) I manage to run `docker-compose up -d` with the web interface showing up.

- The result is mostly a blank page, with a header (with the ClarolineConnect logo) and a footer (showing the version). Is it the expected result ?
- I also trid the login button but none of the credentials I tried work. Given the configuration of this PR, can I log in ?