### PR TITLE
PHP 7.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,10 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.14",
-        "mockery/mockery": "0.9.9",
+        "mockery/mockery": "^1.2",
         "mikey179/vfsstream": "1.6.4",
         "phpmd/phpmd": "@stable",
-        "phpunit/phpunit": "7.1.5",
-        "symfony/phpunit-bridge": "^4.0"
+        "symfony/phpunit-bridge": "^4.4"
     },
     "scripts": {
         "build": [


### PR DESCRIPTION
- Removes `phpunit/phpunit` from composer requirements (use simple-phpunit from symfony/phpunit-bridge instead, handles phpunit installation with cross-version compatibility layers). 
- Upgrades to `mockery/mockery: ^1.2`