### PR TITLE
fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
-language: php
+jobs:
+  include:
+    - php: 7.4
+      env: NODE_RELEASE=14
+      dist: focal # with mysql 8.0
 
-php:
-  - "7.2"
+language: php
 
 env:
   - DB=mysql
@@ -12,10 +15,13 @@ services:
 
 before_install:
   - phpenv config-rm xdebug.ini
-  - nvm install 6.12
+  - nvm install ${NODE_RELEASE}
   # prepare execution of chromium in js tests
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
+  - export ENV=PROD
+  - export APP_ENV=test
+  - export APP_DEBUG=0
 
 before_script:
   # add swap
@@ -28,13 +34,13 @@ before_script:
 
   - composer validate
   - php bin/configure --default
-  - composer update --no-dev
+  - COMPOSER_MEMORY_LIMIT=-1 composer install --optimize-autoloader
   - npm install
-  - composer build
+  - npm run webpack
   - php bin/console claroline:install --env=test -vvv
   - export SYMFONY_DEPRECATIONS_HELPER=weak
 
 script:
-  - vendor/bin/phpunit -c vendor/claroline/distribution
+  - ./vendor/bin/simple-phpunit --dont-report-useless-tests -c vendor/claroline/distribution
   # TODO : enable when JS test suite is fixed
   # - node_modules/.bin/karma start vendor/claroline/distribution/karma.conf.js --single-run

--- a/README.md
+++ b/README.md
@@ -119,14 +119,14 @@ For a development installation, you'll need at least:
     - xml
     - json
     - zip
-- MySQL/MariaDB >=5.0
+- MySQL/MariaDB >= 8.0
 - [composer][composer] (recent version)
-- [node.js][node] >= 8.9
-- [npm][npm] >= 6.4
+- [node.js][node] >= 10
+- [npm][npm] >= 6
 
 It's also highly recommended to develop on an UNIX-like OS.
 
-For mysql >= 5.7, there is an additonal step:
+For mysql >= 8.0, there is an additonal step:
 
 ```
     mysql -u**** -p

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "GPL-3.0",
   "repository": "https://github.com/claroline/Claroline",
   "engines": {
-    "node": ">=6.12",
-    "npm": ">=3.7"
+    "node": ">=10",
+    "npm": ">=6"
   },
   "scripts": {
     "themes": "node vendor/claroline/distribution/main/core/Resources/server/themes/bin build",


### PR DESCRIPTION
Done in this PR:

- ✔️ fix composer memory limit
- ✔️ fix NodeJS compatibility with newer libraries by testing with NodeJS 10+
- ✔️ drop support for unmaintained NodeJS versions 6 and 8
- ✔️ drop support for MySQL lower than 8.0 as per Robin's comments
- ✔️ start testing on MySQL 8.0 (previously only 5.7 was tested)
- ✔️ start testing on all supported versions of PHP (TODO after 30 Nov 2020: remove PHP 7.2 and add PHP 8.0)
- ✔️ fix installation commands, change removed `composer build` to `npm run webpack`
- ✔️ add new ENV vars as per new symfony 4.4 requirements
  ```
  - export ENV=PROD
  - export APP_ENV=test
  - export APP_DEBUG=0
  ```
- ✔️ add three jobs for all currently supported versions of the technical requirements (MySQL 5.7 is no longer supported, but I cannot find a way to configure Travis to use older PHP versions on Focal, or to use newer MySQL version on older Ubuntu versions)
  - ~PHP 7.2 + NodeJS 10 + MySQL 5.7~
  - ~PHP 7.3 + NodeJS 12 + MySQL 5.7~
  - PHP 7.4 + NodeJS 14 + MySQL 8.0

Tests pass since we set `APP_ENV=test`