### PR TITLE
[core] Fix missing call to parent::configure() in *PluginCommand

### DIFF
--- a/src/main/core/Command/Dev/PluginInstallCommand.php
+++ b/src/main/core/Command/Dev/PluginInstallCommand.php
@@ -22,6 +22,7 @@ class PluginInstallCommand extends AbstractPluginCommand
 {
     protected function configure()
     {
+        parent::_configure();
         $this->setDescription('Installs a specified claroline plugin.');
     }
 

--- a/src/main/core/Command/Dev/PluginUninstallCommand.php
+++ b/src/main/core/Command/Dev/PluginUninstallCommand.php
@@ -22,6 +22,7 @@ class PluginUninstallCommand extends AbstractPluginCommand
 {
     protected function configure()
     {
+        parent::_configure();
         $this->setDescription('Uninstalls a specified claroline plugin.');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed issues | -

Broken since https://github.com/claroline/distribution/pull/6762

