### PR TITLE
fixes mailer encryption parameter

### DIFF
--- a/src/main/core/Library/Mailing/TransportFactory.php
+++ b/src/main/core/Library/Mailing/TransportFactory.php
@@ -60,9 +60,6 @@ class TransportFactory
 
         // Default smtp
         $encryption = 'none' === $this->configHandler->getParameter('mailer_encryption') ? false : null; // null lets the transport choose the best value based on the platform.
-        if (!empty($this->configHandler->getParameter('mailer_encryption'))) {
-            $encryption = (bool) $this->configHandler->getParameter('mailer_encryption');
-        }
 
         $transport = new EsmtpTransport(
             $this->configHandler->getParameter('mailer_host'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

Because `(bool) 'none' === true` it is no longer possible to disable tls.


