### PR TITLE
Use direct push instead of a PR for releases

### DIFF
--- a/.github/workflows/release_patch.yml
+++ b/.github/workflows/release_patch.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASER_TOKEN }}
 
       - name: Update VERSION/CHANGELOG
         id: bump
@@ -25,33 +26,9 @@ jobs:
           git config --global user.email robin.chalas@gmail.com
           git add changelogs/ VERSION.txt
           git commit -m "Release version ${NEW_TAG}"
+          git push origin $RELEASE_BRANCH
         env:
           RELEASE_BRANCH: 13.x
-
-      - name: Set auth token
-        run: git remote set-url origin https://x-access-token:${{ secrets.RELEASER_TOKEN }}@github.com/$GITHUB_REPOSITORY
-
-      - name: Create Release PR
-        id: release-pr
-        uses: peter-evans/create-pull-request@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: Release version ${{ steps.bump.outputs.tag }}
-          branch: release-${{ steps.bump.outputs.tag }}
-          delete-branch: true
-
-      - name: Approve Release PR
-        uses: juliangruber/approve-pull-request-action@v1
-        with:
-          github-token: ${{ secrets.RELEASER_TOKEN }}
-          number: ${{ steps.release-pr.outputs.pull-request-number }}
-
-      - name: Merge Release PR
-        uses: juliangruber/merge-pull-request-action@v1
-        with:
-          github-token: ${{ secrets.RELEASER_TOKEN }}
-          number: ${{ steps.release-pr.outputs.pull-request-number }}
-          method: squash
 
       - name: Create Tag
         uses: anothrNick/github-tag-action@1.34.0


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Fixed issues | no

By using the secret `RELEASER_TOKEN` (ClaroBot's token) in the `checkout ` step, we are able to bypass restrictions/required status checks when pushing on protected branches.


