### PR TITLE
Fix docker-compose GA workflow

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,5 +1,8 @@
 name: Docker Compose Actions Workflow
 
+on:
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,7 +1,6 @@
 name: Docker Compose Actions Workflow
 
-on:
-  workflow_dispatch:
+on: workflow_dispatch
 
 jobs:
   build:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Fixed issues | comma-separated list of issues fixed by the PR, if any

The workflow misses the mandatory top-level key `on:`, this adds one. Should fix the alerts about the non runnable workflow that are triggered when merging PRs.

