### PR TITLE
Fix broken state after cache:clear

### DIFF
--- a/src/main/kernel/ClarolineKernelBundle.php
+++ b/src/main/kernel/ClarolineKernelBundle.php
@@ -11,6 +11,7 @@
 
 namespace Claroline\KernelBundle;
 
+use Claroline\CoreBundle\Library\Maintenance\MaintenanceHandler;
 use Claroline\KernelBundle\Bundle\ConfigurationBuilder;
 use Claroline\KernelBundle\Manager\BundleManager;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -44,7 +45,7 @@ class ClarolineKernelBundle extends Bundle
     {
         $bundles = [];
 
-        foreach ($this->bundleManager->getActiveBundles('test' === $this->kernel->getEnvironment()) as $bundle) {
+        foreach ($this->bundleManager->getActiveBundles(MaintenanceHandler::isMaintenanceEnabled() || 'test' === $this->kernel->getEnvironment()) as $bundle) {
             $bundles[] = $bundle[BundleManager::BUNDLE_INSTANCE];
         }
 
@@ -57,7 +58,7 @@ class ClarolineKernelBundle extends Bundle
 
     public function loadConfigurations(LoaderInterface $loader)
     {
-        foreach ($this->bundleManager->getActiveBundles('test' === $this->kernel->getEnvironment()) as $bundle) {
+        foreach ($this->bundleManager->getActiveBundles(MaintenanceHandler::isMaintenanceEnabled() || 'test' === $this->kernel->getEnvironment()) as $bundle) {
             foreach ($bundle[BundleManager::BUNDLE_CONFIG]->getContainerResources() as $resource) {
                 $loader->load(
                     $resource[ConfigurationBuilder::RESOURCE_OBJECT],

--- a/src/main/kernel/Manager/BundleManager.php
+++ b/src/main/kernel/Manager/BundleManager.php
@@ -16,6 +16,7 @@ use Claroline\KernelBundle\Bundle\AutoConfigurableInterface;
 use Claroline\KernelBundle\Bundle\ConfigurationBuilder;
 use Claroline\KernelBundle\Bundle\ConfigurationProviderInterface;
 use Claroline\KernelBundle\Bundle\PluginBundleInterface;
+use Claroline\KernelBundle\ClarolineKernelBundle;
 use Psr\Log\LoggerAwareInterface;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -55,10 +56,9 @@ class BundleManager implements LoggerAwareInterface
         $configProviderBundles = [];
         $nonAutoConfigurableBundles = [];
         $environment = $this->getEnvironment();
-        $updateMode = 'cli' === PHP_SAPI;
 
         foreach ($entries as $bundleClass => $isActive) {
-            if (((bool) $isActive || $fetchAll || $updateMode) && 'Claroline\KernelBundle\ClarolineKernelBundle' !== $bundleClass) {
+            if (((bool) $isActive || $fetchAll) && ClarolineKernelBundle::class !== $bundleClass) {
                 if (class_exists($bundleClass)) {
                     /** @var BundleInterface $bundle */
                     $bundle = new $bundleClass($this->kernel);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed issues | -

Running any command produces a wrong cache (all plugins are loaded even though they are not all activated, which is only needed when installing or updating a platform). This PR fixes it.