### PR TITLE
fixes ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,38 +24,45 @@ jobs:
         run: |
           git fetch origin
           git diff --name-only --diff-filter=AM origin/${{ github.base_ref }} > git_diff_files.txt
-          echo "::set-output name=diff::$(cat git_diff_files.txt)"
+          echo "::set-output name=diff_php::$(cat git_diff_files.txt | grep '.\+\.php' | sed ':a;N;$!ba;s/\n/ /g')"
+          echo "::set-output name=diff_js::$(cat git_diff_files.txt | grep 'Resources/modules/.\+\.js' | sed ':a;N;$!ba;s/\n/ /g')"
 
       - name: "Install PHPMD"
-        run: if [ "$DIFF" != '' ]; then wget -c https://phpmd.org/static/latest/phpmd.phar -O phpmd; fi
+        if: ${{ env.DIFF != '' }}
+        run: wget -c https://phpmd.org/static/latest/phpmd.phar -O phpmd;
         env:
-          DIFF: ${{ steps.diff.outputs.diff }}
+          DIFF: ${{ steps.diff.outputs.diff_php}}
 
       - name: "Run PHPMD checks"
-        run: if [ "$DIFF" != '' ]; then php phpmd `echo "$DIFF" | xargs | sed -e :a -e '$!N; s/ /,/; ta'` text phpmd.xml; fi
+        if: ${{ env.DIFF != '' }}
+        run: php phpmd `echo "$DIFF" | tr ' ' ','` text phpmd.xml
         env:
-          DIFF: ${{ steps.diff.outputs.diff }}
+          DIFF: ${{ steps.diff.outputs.diff_php }}
 
       - name: "Install PHPCSFixer"
-        run: if [ "$DIFF" != '' ]; then wget https://cs.symfony.com/download/php-cs-fixer-v2.phar -O php-cs-fixer; fi
+        if: ${{ env.DIFF != '' }}
+        run: wget https://cs.symfony.com/download/php-cs-fixer-v2.phar -O php-cs-fixer
         env:
-          DIFF: ${{ steps.diff.outputs.diff }}
+          DIFF: ${{ steps.diff.outputs.diff_php }}
 
       - name: "Run PHPCSFixer checks"
-        run: if [ "$DIFF" != '' ]; then php php-cs-fixer fix --dry-run --diff --config=.php_cs; fi
+        if: ${{ env.DIFF != '' }}
+        run: php php-cs-fixer fix --dry-run --diff --config=.php_cs --path-mode=intersection `echo "$DIFF"`
         env:
           PHP_CS_FIXER_IGNORE_ENV: 1
-          DIFF: ${{ steps.diff.outputs.diff }}
+          DIFF: ${{ steps.diff.outputs.diff_php }}
 
       - name: "Install ESLint"
-        run: if [ "$DIFF" != '' ]; then npm install eslint eslint-plugin-react@7.21.5; fi
+        if: ${{ env.DIFF != '' }}
+        run: npm install eslint eslint-plugin-react@7.21.5
         env:
-          DIFF: ${{ steps.diff.outputs.diff }}
+          DIFF: ${{ steps.diff.outputs.diff_js }}
 
       - name: "Run ESLint checks"
-        run: if [ "$DIFF" != '' ]; then node_modules/.bin/eslint --ext js --ext jsx `echo "$DIFF" | grep 'Resources/modules/.\+\.js' | tr '\n' ' '`; fi
+        if: ${{ env.DIFF != '' }}
+        run: node_modules/.bin/eslint --ext js --ext jsx `echo "$DIFF"`
         env:
-          DIFF: ${{ steps.diff.outputs.diff }}
+          DIFF: ${{ steps.diff.outputs.diff_js }}
 
   php:
     name: "PHPUnit (PHP 7.4)"

--- a/.php_cs
+++ b/.php_cs
@@ -1,32 +1,6 @@
 <?php
 
-/*******************************************************************************
- * This script is a config file for PHP-CS-Fixer designed for CI builds.
- * It reads a list of targets (supposably files changed by the push/PR) from
- * a file located in the root directory and passed them to the CS config (with
- * default fixer level: Symfony).
- ******************************************************************************/
-
-$pkgDir = realpath(__DIR__);
-$targetFile = "{$pkgDir}/git_diff_files.txt";
-
-if (!file_exists($targetFile)) {
-    echo "Cannot find file listing CS targets (looked for {$targetFile})\n";
-    exit(1);
-}
-
-$targets = array_filter(file($targetFile), function ($line) {
-    $line = trim($line);
-    $length = strlen($line);
-
-    return $length > 4 && strpos($line, '.php') === $length - 4;
-});
-
-$files = array_map(function ($filePath) use ($pkgDir) {
-    return "{$pkgDir}/".trim($filePath);
-}, $targets);
-
-$finder = PhpCsFixer\Finder::create()->append($files);
+$finder = PhpCsFixer\Finder::create()->in(__DIR__);
 
 return PhpCsFixer\Config::create()
     ->setRules([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

Because github actions truncates multilines in `env` and `output` vars (see https://github.com/actions/toolkit/issues/403).
The diff for PHPMD and ESLint was always wrong. PHP CS Fixer was working because it was using its own diff.

I have also added the following changes : 
- Update PHP CS Fixer to use the same diff than other linters.
- Use 2 diffs, one for JS and one for PHP. This allows to avoid installing php linters if only js has been modified and vice versa.

