### PR TITLE
[Docker] development setup

### DIFF
--- a/.docker.dev/mysql/my.cnf
+++ b/.docker.dev/mysql/my.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+
+sql_mode = ""
+default_authentication_plugin = "mysql_native_password"

--- a/.docker.dev/web/Dockerfile
+++ b/.docker.dev/web/Dockerfile
@@ -1,0 +1,53 @@
+FROM php:7.4-apache
+
+LABEL maintainer="Donovan Tengblad"
+
+RUN a2enmod rewrite expires ssl headers
+
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash
+RUN apt-get update && apt-get install -y \
+  git \
+  mariadb-client \
+  wget \
+  unzip \
+  zip \
+  libxml2-dev \
+  libmcrypt-dev \
+  libcurl4-gnutls-dev \
+  xz-utils \
+  xfonts-75dpi \
+  libldap2-dev \
+  libpng-dev \
+  libjpeg-dev \
+  zlib1g-dev \
+  libicu-dev \
+  libzip-dev \
+  libonig-dev \
+  g++ \
+  ssl-cert \
+  curl \
+  nodejs\
+  && rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-install -j$(nproc) xml mysqli curl zip mbstring gettext pdo_mysql gd exif mbstring
+RUN docker-php-ext-configure intl
+RUN docker-php-ext-install intl
+
+RUN curl -sS https://getcomposer.org/installer | php
+RUN mv composer.phar /usr/local/bin/composer
+
+RUN pecl install apcu-beta \
+  && echo extension=apcu.so > /usr/local/etc/php/conf.d/apcu.ini
+
+COPY ./.docker.dev/web/config/php.ini /usr/local/etc/php/
+COPY ./.docker.dev/web/files/apache2/claroline.conf /etc/apache2/sites-available/
+COPY ./.docker.dev/web/files/apache2/claroline-ssl.conf /etc/apache2/sites-available/
+RUN a2dissite 000-default && a2dissite default-ssl && a2ensite claroline.conf
+
+COPY . /var/www/html/claroline
+WORKDIR /var/www/html/claroline
+
+COPY ./.docker.dev/web/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/.docker.dev/web/config/php.ini
+++ b/.docker.dev/web/config/php.ini
@@ -1,0 +1,7 @@
+file_uploads = On
+memory_limit = 4G
+upload_max_filesize = 256M
+post_max_size = 256M
+max_execution_time = 600
+short_open_tag = false
+date.timezone = "Europe/Paris"

--- a/.docker.dev/web/entrypoint.sh
+++ b/.docker.dev/web/entrypoint.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -e
+
+# Wait for MySQL to respond, depends on mysql-client
+echo "Waiting for $DB_HOST..."
+while ! mysqladmin ping -h "$DB_HOST" --silent; do
+  echo "MySQL is down"
+  sleep 1
+done
+
+echo "MySQL is up"
+
+if [ -f files/installed ]; then
+  echo "Claroline is already installed"
+
+  if [ -f files/versionLastUsed.txt ]; then
+    versionLastUsed=$(head -n 1 files/versionLastUsed.txt)
+    currentVersion=$(head -n 1 VERSION.txt)
+
+    if [[ "$versionLastUsed" != "$currentVersion" ]]; then
+      echo "New version detected, updating..."
+      php bin/configure
+      php bin/check
+      composer install
+      npm install
+      php bin/console claroline:update --env=dev -vvv
+      chmod -R 777 var files config
+      composer delete-cache # fixes SAML errors
+    else
+      echo "Claroline version is up to date"
+    fi
+  fi
+else
+  echo "Installing Claroline..."
+  php bin/configure
+  php bin/check
+  composer install
+  npm install
+  php bin/console claroline:install --env=dev -vvv
+
+  if [[ -v PLATFORM_NAME ]]; then
+    echo "Changing platform name to $PLATFORM_NAME";
+    sed -i "/name: claroline/c\name: $PLATFORM_NAME" files/config/platform_options.json
+  fi
+
+  if [[ -v PLATFORM_SUPPORT_EMAIL ]]; then
+    echo "Changing platform support email to $PLATFORM_SUPPORT_EMAIL";
+    sed -i "/support_email: null/c\support_email: $PLATFORM_SUPPORT_EMAIL" files/config/platform_options.json
+  fi
+
+  USERS=$(mysql $DB_NAME -u $DB_USER -p$DB_PASSWORD -h $DB_HOST -se "select count(*) from claro_user")
+
+  if [ "$USERS" == "0" ] && [ -v ADMIN_FIRSTNAME ] && [ -v ADMIN_LASTNAME ] && [ -v ADMIN_USERNAME ] && [ -v ADMIN_PASSWORD ]  && [ -v ADMIN_EMAIL ]; then
+    echo '*********************************************************************************************************************'
+    echo "Creating default admin user : $ADMIN_FIRSTNAME $ADMIN_LASTNAME $ADMIN_USERNAME $ADMIN_PASSWORD $ADMIN_EMAIL"
+    echo '*********************************************************************************************************************'
+
+    php bin/console claroline:user:create -a $ADMIN_FIRSTNAME $ADMIN_LASTNAME $ADMIN_USERNAME $ADMIN_PASSWORD $ADMIN_EMAIL
+  else
+    echo 'Users already exist or no admin vars detected, Claroline installed without an admin account'
+  fi
+
+  echo "Setting correct file permissions"
+  chmod -R 777 var files config
+
+  echo "Clean cache after setting correct permissions, fixes SAML issues"
+  composer delete-cache
+  touch files/installed
+fi
+
+cp VERSION.txt files/versionLastUsed.txt
+
+echo "webpack-dev-server starting as a background process..."
+nohup npm run webpack:dev -- --host=0.0.0.0 --disable-host-check &
+
+echo "Starting Apache2 in the foreground"
+exec "$@"

--- a/.docker.dev/web/files/apache2/claroline-ssl.conf
+++ b/.docker.dev/web/files/apache2/claroline-ssl.conf
@@ -1,0 +1,5 @@
+Listen 443
+SSLEngine on
+DocumentRoot /var/www/html/claroline/public
+
+#entrypoint.sh appended configuration

--- a/.docker.dev/web/files/apache2/claroline.conf
+++ b/.docker.dev/web/files/apache2/claroline.conf
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+        DocumentRoot /var/www/html/claroline/public
+        <Directory /var/www/html/claroline/public>
+                AllowOverride None
+                Order Allow,Deny
+                Allow from All
+
+                <IfModule mod_rewrite.c>
+                    Options -MultiViews
+                    RewriteEngine On
+                    RewriteCond %{REQUEST_FILENAME} !-f
+                    RewriteRule ^(.*)$ index.php [QSA,L]
+                </IfModule>
+        </Directory>
+</VirtualHost>

--- a/.github/workflows/dockerimage.dev.yml
+++ b/.github/workflows/dockerimage.dev.yml
@@ -1,0 +1,15 @@
+name: Docker DEV
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the stack
+        # run: docker-compose up # remove -d in order to see the build output in gh actions for debugging - you'll need to cancel the run manually once it's done
+        run: docker-compose -f docker-compose.dev.yml up -d
+      - name: Test 127.0.0.1
+        run: docker run --network container:claroline-web curlimages/curl -s  --connect-timeout 30 --max-time 600 --retry 20 --retry-delay 30 --retry-max-time 600 --retry-all-errors http://127.0.0.1/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ file. For an installation from scratch, the commands would be:
     
     php bin/console claroline:install -vvv
 
+### 2. Using Docker (development only - beginner-friendly guide)
+
+**Warning**: this is for development/testing purposes *only*, this must **NOT** be used in production environments as it represents huge security risks, maintainability issues and performance degradations.
+
+As a developer, by using Docker you can quickly get the platform running in DEV mode and experiment with code changes.
+
+You can also develop a custom theme in watch mode.
+
+To learn more: [Docker instructions](doc/sections/docker.md)
+
 Upgrade 13.x
 -------
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -27,6 +27,7 @@ Structure
     - [Themes][9]
     - [Logs][13]
 - [Development tools][10]
+- [Docker][19]
 
 [1]: ../../../../../../README.md
 [2]: sections/overview.md
@@ -45,3 +46,4 @@ Structure
 [16]: best-practices/front-end.md
 [17]: libraries/api.md
 [18]: libraries/front-end.md
+[19]: sections/docker.md

--- a/doc/sections/docker.md
+++ b/doc/sections/docker.md
@@ -1,0 +1,46 @@
+## Using Docker (development only - beginner-friendly guide)
+
+**Warning**: this is for development/testing purposes *only*, this must **NOT** be used in production environments as it represents huge security risks, maintainability issues and performance degradations.
+
+As a developer, by using Docker you can quickly get the platform running in DEV mode and experiment with code changes.
+
+### Requirements:
+
+* Docker Engine (latest)
+* docker-compose (latest)
+
+**Windows 10 Users**: you can follow the official guide to install WSL 2 and then Docker Desktop:
+
+[Docker Desktop WSL 2 backend](https://docs.docker.com/docker-for-windows/wsl/)
+
+Then clone the project into your WSL's user folder (for example, `cd ~` and then `git clone` this repo's URL), then navigate into the new project folder (`cd Claroline`).
+
+### Starting Docker
+
+In the project folder, run the following command (it may take 5-10 minutes, in the end you should see that webpack-dev-server has compiled the UI, you may ignore any warnings):
+
+```sh
+docker-compose -f docker-compose.dev.yml up
+```
+
+Then you can open [http://localhost/](http://localhost/) and you should see the login page, this means that the project was started successfully.
+
+### Login
+
+You can use the admin credentials from the *docker-compose.dev.yml* file and you are strongly advised to change the default password.
+
+### Development
+
+When you modify ReactJS components, the page will automatically refresh.
+
+When you modify PHP files, you'll need to manually refresh the page.
+
+### Rebuilding your theme in watch mode
+
+While running the containers, open a new console in the project folder and run the following command (replace "yourthemename" with the name of your theme):
+
+```sh
+docker exec -it claroline-web npx nodemon -e less --watch files/themes-src/yourthemename --exec 'php bin/console claroline:theme:build --theme=yourthemename'
+```
+
+If you're working on one of the core themes (the ones included with Claroline), you can adapt this command by changing the folder to watch and by passing the theme's name.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,59 @@
+version: "3.7"
+
+services:
+  web:
+    container_name: claroline-web
+    build:
+      context: .
+      dockerfile: .docker.dev/web/Dockerfile
+    ports:
+      - "80:80"
+      - "8080:8080"
+    volumes:
+      - ./:/var/www/html/claroline/
+    depends_on:
+      - db
+    environment:
+      - APP_URL=claroline.example.com
+      - ENV=DEV
+      - APP_ENV=dev
+      - APP_DEBUG=1
+      - DB_HOST=claroline-db
+      - DB_NAME=claroline
+      - DB_USER=claroline
+      - DB_PASSWORD=claroline
+      - SECRET="secret-claroline"
+      - ADMIN_FIRSTNAME=John
+      - ADMIN_LASTNAME=Doe
+      - ADMIN_USERNAME=root
+      - ADMIN_PASSWORD=claroline
+      - ADMIN_EMAIL=claroline@example.com
+      - PLATFORM_NAME=Claroline
+      - PLATFORM_SUPPORT_EMAIL=claroline@example.com
+    networks:
+      claroline_network:
+        ipv4_address: 172.22.9.6
+
+  db:
+    container_name: claroline-db
+    environment:
+      MYSQL_ROOT_PASSWORD: claroline
+      MYSQL_USER: claroline
+      MYSQL_PASSWORD: claroline
+      MYSQL_DATABASE: claroline
+    image: mysql:8.0
+    command: --sql_mode="" --default_authentication_plugin="mysql_native_password"
+    ports:
+      - "3306:3306"
+    volumes:
+      - ../mysql:/var/lib/mysql
+      - ./.docker.dev/mysql:/etc/mysql/conf.d # TODO check why is world-writable config file ignored, shall we make it read-only? When and how?
+    networks:
+      claroline_network:
+        ipv4_address: 172.22.9.5
+
+networks:
+  claroline_network:
+    ipam:
+      config:
+        - subnet: 172.22.9.0/24


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Fixed issues | none

## Goals

Reducing the overhead of contributing to Claroline by providing a predefined environment that can be started using a single `docker-compose` command, thus allowing developers to inspect the UI using browser extensions like [React Devtools](https://github.com/facebook/react/tree/master/packages/react-devtools) and [Redux Devtools](https://github.com/reduxjs/redux-devtools) as well as to see their file changes upon refresh.

## How

By using Docker for development, new contributors can get started faster by focusing on their code changes instead of spending hours setting up their environment for the first time.
It's also a representation of the sequence of steps required to set up a dev environment and to install and run Claroline in DEV mode, so it's like a self-documenting process.

## Getting started

`docker-compose -f docker-compose.dev.yml up`

## What's new

Created a copy of the current docker configuration with the following changes:
* docker-compose dev config file:
  * port 8080:8080 is open so that localhost can access webpack-dev-server
  * the entire project is in a volume so that we can easily modify files from outside and see the results
  * ENV=DEV
  * APP_ENV=dev
  * APP_DEBUG=1
  * use the new .docker.dev/ folder
* Dockerfile:
  * do not run any installation commands, leave that to the entrypoint for simplicity
* entrypoint.sh:
  * install and build everything instead of relying on Dockerfile
  * simply `composer install`, no other params
  * `claroline:update --env=dev` and `claroline:install --env=dev`
  * all files have the 777 permissions so that we don't have to deal with permissions and owners during development
  * run webpack:dev as a background process and accept any host so that it works in Docker from outside
* better Github Action - reduced the time before `curl` fails, it now retries for 10 minutes and then fails (the dev build usually takes 4-5 minutes, so we give it enough time)
* Instructions for getting started with Docker
* Instructions for theme development in watch mode with Docker

## New GH Actions build:

https://github.com/maieutiquer/Claroline/actions/runs/772492312

## Result

We see Symfony's debug toolbar:
![image](https://user-images.githubusercontent.com/1476049/115702738-f4e1c200-a371-11eb-84d6-c21df14a962a.png)

React warnings are printed in the console:
![image](https://user-images.githubusercontent.com/1476049/115702997-425e2f00-a372-11eb-9021-93a0fa21dcdd.png)

React Devtools' Components tab displays the real component names, not obfuscated ones:
![image](https://user-images.githubusercontent.com/1476049/115703631-04add600-a373-11eb-9dd3-74b0cb0502c6.png)

Redux Devtools is fully enabled:
![image](https://user-images.githubusercontent.com/1476049/115704132-a9301800-a373-11eb-99cc-43569e0fdb8d.png)
