### PR TITLE
fixes resources opening

### DIFF
--- a/src/main/core/Manager/ResourceManager.php
+++ b/src/main/core/Manager/ResourceManager.php
@@ -23,6 +23,7 @@ use Claroline\CoreBundle\Entity\Resource\ResourceType;
 use Claroline\CoreBundle\Entity\Role;
 use Claroline\CoreBundle\Entity\User;
 use Claroline\CoreBundle\Entity\Workspace\Workspace;
+use Claroline\CoreBundle\Event\CatalogEvents\ResourceEvents;
 use Claroline\CoreBundle\Event\Resource\DownloadResourceEvent;
 use Claroline\CoreBundle\Event\Resource\LoadResourceEvent;
 use Claroline\CoreBundle\Exception\ExportResourceException;
@@ -602,7 +603,7 @@ class ResourceManager implements LoggerAwareInterface
         if ($resource) {
             /** @var LoadResourceEvent $event */
             $event = $this->dispatcher->dispatch(
-                'resource_load',
+                ResourceEvents::RESOURCE_OPEN,
                 LoadResourceEvent::class,
                 [$resource, $this->security->getUser(), $embedded]
             );

--- a/src/main/core/Subscriber/Log/FunctionalLogSubscriber.php
+++ b/src/main/core/Subscriber/Log/FunctionalLogSubscriber.php
@@ -24,9 +24,9 @@ class FunctionalLogSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ResourceEvents::RESOURCE_EVALUATION => 'logEvent',
-            ResourceEvents::RESOURCE_OPEN => 'logEvent',
-            ToolEvents::TOOL_OPEN => 'logEvent',
+            ResourceEvents::RESOURCE_EVALUATION => ['logEvent', 10],
+            ResourceEvents::RESOURCE_OPEN => ['logEvent', 10],
+            ToolEvents::TOOL_OPEN => ['logEvent', 10],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no


This is a quickfix.
Because of https://github.com/claroline/Claroline/blob/13.x/src/main/core/Subscriber/Log/FunctionalLogSubscriber.php#L47, if the log subscriber is not executed before implementations, loaded data is lost.

The correct fix is to remove the call to `$event->setData` in the log event but for now it is required for the generic tool open event. The event has a validation which checks if the event has been populated and throws an exception otherwise.

