### PR TITLE
Add support and styles for sub tabs in the top navigation

### DIFF
--- a/src/main/core/Library/Configuration/PlatformDefaults.php
+++ b/src/main/core/Library/Configuration/PlatformDefaults.php
@@ -30,6 +30,7 @@ class PlatformDefaults implements ParameterProviderInterface
         return [
             'meta' => [],
             'home' => [
+                'show_sub_menu' => false,
                 'type' => 'none',
                 'data' => null,
                 'menu' => null,

--- a/src/plugin/home/Resources/modules/tools/home/components/page.jsx
+++ b/src/plugin/home/Resources/modules/tools/home/components/page.jsx
@@ -25,6 +25,7 @@ const HomePage = props =>
         prefix={props.basePath+props.path}
         tabs={props.tabs}
         currentContext={props.currentContext}
+        showSubMenu={props.showSubMenu}
       /> : undefined
     }
     icon={props.currentTab && props.currentTab.icon ?
@@ -75,6 +76,7 @@ const HomePage = props =>
   </ToolPage>
 
 HomePage.propTypes = {
+  showSubMenu: T.bool,
   path: T.string,
   breadcrumb: T.array,
   title: T.string.isRequired,

--- a/src/plugin/home/Resources/modules/tools/home/components/tabs.jsx
+++ b/src/plugin/home/Resources/modules/tools/home/components/tabs.jsx
@@ -1,7 +1,7 @@
-import React from 'react'
+import React, {useEffect, useState} from 'react'
 import {PropTypes as T} from 'prop-types'
 import classes from 'classnames'
-import get from 'lodash/get'
+import {get, isEmpty} from 'lodash'
 
 import {trans} from '#/main/app/intl/translation'
 import {Button} from '#/main/app/action/components/button'
@@ -10,27 +10,73 @@ import {LinkButton} from '#/main/app/buttons/link/components/button'
 
 import {Tab as TabTypes} from '#/plugin/home/prop-types'
 
-const Tabs = props =>
-  <nav className="tool-nav">
-    {props.tabs.map((tab) =>
-      <LinkButton
-        key={tab.id}
-        className={classes('nav-tab', {
-          'nav-tab-hidden': get(tab, 'restrictions.hidden')
-        })}
-        target={`${props.prefix}/${tab.slug}`}
-        activeStyle={{
-          backgroundColor: get(tab, 'display.color'),
-          borderColor: get(tab, 'display.color')
-        }}
-      >
-        {tab.icon &&
+const Tab = ({tab, prefix, closeTab, isChild=false}) => <LinkButton
+  key={tab.id}
+  className={classes('nav-tab', {
+    'nav-tab-hidden': get(tab, 'restrictions.hidden'),
+    'top-tab': !isChild,
+    'dropdown-tab': isChild
+  })}
+  target={`${prefix}/${tab.slug}`}
+  activeStyle={{
+    backgroundColor: get(tab, 'display.color'),
+    borderColor: get(tab, 'display.color')
+  }}
+  onClick={closeTab}
+>
+  {tab.icon &&
           <span className={classes('fa fa-fw', `fa-${tab.icon}`, tab.title && 'icon-with-text-right')} />
-        }
+  }
+  {tab.title}
+</LinkButton>
 
-        {tab.title}
-      </LinkButton>
-    )}
+const Tabs = props => {
+  const [expandedTab, setExpandedTab] = useState('')
+  useEffect(() => {
+    const previousWindowOnClick = window.onclick
+
+    window.onclick = ({target}) => !target.matches('top-tabs') && setExpandedTab('')
+
+    return () => {
+      window.onclick = previousWindowOnClick
+    }
+  }, [])
+
+  const toggleTab = tab => {
+    const newState = tab.id === expandedTab ? '' : tab.id
+    setExpandedTab(newState)
+  }
+  const isTabExpanded = tab => tab.id === expandedTab
+
+  const getSubtabs = (subtabs) => <ul className="dropdown-tabs">{subtabs.map(subtab => <li className="dropdown-tab-item" key={subtab.id}>
+    <Tab tab={subtab} prefix={props.prefix} isChild={true} closeTab={() => setExpandedTab('')} />
+  </li>)}</ul>
+
+  const getTabs = (tab) => {
+    const canShowSubTabs = !isEmpty(tab.children) && props.showSubMenu
+
+    return <li className={classes('top-tab-item', {'dropdown': canShowSubTabs})} key={tab.id}>
+      <div className="top-item">
+        <Tab tab={tab} prefix={props.prefix} closeTab={() => setExpandedTab('')} />
+        {canShowSubTabs && <Button
+          className="expand-sub-menu"
+          type={CALLBACK_BUTTON}
+          icon={classes('fa fa-fw', {
+            'fa-caret-up': isTabExpanded(tab),
+            'fa-caret-down': !isTabExpanded(tab)
+          })}
+          label=""
+          callback={() => toggleTab(tab)}
+        />}
+      </div>
+      {canShowSubTabs && isTabExpanded(tab) && getSubtabs(tab.children)}
+    </li>
+  }
+
+  return <nav className="tool-nav">
+    <ul className="top-tabs">
+      {props.tabs.map(getTabs)}
+    </ul>
 
     {props.create &&
       <Button
@@ -43,8 +89,10 @@ const Tabs = props =>
       />
     }
   </nav>
+}
 
 Tabs.propTypes = {
+  showSubMenu: T.bool,
   prefix: T.string,
   tabs: T.arrayOf(T.shape(
     TabTypes.propTypes

--- a/src/plugin/home/Resources/modules/tools/home/containers/page.jsx
+++ b/src/plugin/home/Resources/modules/tools/home/containers/page.jsx
@@ -5,6 +5,7 @@ import {selectors as toolSelectors} from '#/main/core/tool/store'
 
 import {HomePage as HomePageComponent} from '#/plugin/home/tools/home/components/page'
 import {actions, selectors} from '#/plugin/home/tools/home/store'
+import {selectors as configSelectors} from '#/main/app/config/store'
 
 const HomePage = connect(
   (state) => ({
@@ -13,7 +14,8 @@ const HomePage = connect(
     canEdit: hasPermission('edit', toolSelectors.toolData(state)),
     canAdministrate: hasPermission('administrate', toolSelectors.toolData(state)),
 
-    administration: selectors.administration(state)
+    administration: selectors.administration(state),
+    showSubMenu: configSelectors.param(state, 'home.show_sub_menu')
   }),
   (dispatch) => ({
     setAdministration(administration) {

--- a/src/plugin/home/Resources/styles/home.less
+++ b/src/plugin/home/Resources/styles/home.less
@@ -14,6 +14,45 @@
 
   margin: 0 floor((@grid-gutter-width / 2) - 5px);
 
+  .top-tabs {
+    display: flex;
+    padding-left: 0;
+    margin-bottom: 0;
+    list-style: none;
+  }
+
+  .top-tab.active::after {
+    position: absolute;
+    content: " ";
+    width: 0;
+    height: 0;
+    left: 50%;
+    top: 100%;
+    transform: translate(-50%, 0);
+    border-style: solid;
+    border-width: 5px 5px 0 5px;
+
+    // attention : this can not be written with short syntax
+    border-color: transparent;
+    border-top-color: inherit;
+  }
+
+  .top-tab-item.dropdown {
+    position: relative;
+
+    .top-tab {
+      margin-right: 0;
+      padding: @padding-large-vertical @padding-large-horizontal;
+    }
+  }
+
+  .dropdown-tabs {
+    position: absolute;
+    padding-left: @padding-large-vertical / 2;
+    list-style: none;
+    z-index: 1;
+  }
+
   .nav-tab-hidden {
     color: @text-muted;
     text-decoration: line-through;
@@ -41,21 +80,37 @@
 
       .text-movie-subtitles();
       .box-shadow(0 0 3px rgba(0, 0, 0, 0.5));
+    }
+  }
 
-      &:after {
-        position: absolute;
-        content: " ";
-        width: 0;
-        height: 0;
-        left: 50%;
-        top: 100%;
-        transform: translate(-50%, 0);
-        border-style: solid;
-        border-width: 5px 5px 0 5px;
+  .nav-tab {
+    display: block;
+    text-decoration: none;
+    white-space: nowrap;
 
-        // attention : this can not be written with short syntax
-        border-color: transparent;
-        border-top-color: inherit;
+    &.dropdown-tab {
+      margin: 0;
+      border-radius: unset;
+    }
+  }
+
+  .top-item {
+    display: flex;
+
+    .expand-sub-menu {
+      height: auto;
+      padding-left: 7px;
+  
+      color: @home-tab-color;
+      background: @home-tab-bg;
+  
+      border-left: 1px solid;
+      margin: @padding-xs-horizontal 0;
+
+      &:hover {
+        color: @home-tab-hover-color;
+        background: @home-tab-hover-bg;
+        .box-shadow(@box-shadow-base);
       }
     }
   }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no

The following PR makes it possible to show dropdown menus in the top horizontal navigation. This behaviour is controlled by a flag that is used to enable/disable the feature - `show_sub_menu` (defaults to `false`)

![image](https://user-images.githubusercontent.com/26501599/118653636-6cc7ce80-b7f0-11eb-9779-60f6283cb5d5.png)

![image](https://user-images.githubusercontent.com/26501599/118653522-4dc93c80-b7f0-11eb-8d3d-97ee811ca6d9.png)

![image](https://user-images.githubusercontent.com/26501599/118653570-5ae62b80-b7f0-11eb-9a68-922e3aa5e45f.png)

