### PR TITLE
[Saml] allows to assign users to organization on creation

### DIFF
--- a/src/plugin/saml/Configuration/PlatformDefaults.php
+++ b/src/plugin/saml/Configuration/PlatformDefaults.php
@@ -19,6 +19,8 @@ class PlatformDefaults implements ParameterProviderInterface
     {
         return [
             'saml' => [
+                // an organization to bind users to when created from saml
+                'organization_id' => null,
                 'active' => false,
                 'entity_id' => 'claroline', // the sp name
                 'credentials' => [], // the app certificates and secrets

--- a/src/plugin/saml/Resources/config/services/security.yml
+++ b/src/plugin/saml/Resources/config/services/security.yml
@@ -27,6 +27,7 @@ services:
             - '@security.token_storage'
             - '@Claroline\AuthenticationBundle\Security\Authentication\Authenticator'
             - '@lightsaml_sp.username_mapper.simple'
+            - '@Claroline\CoreBundle\Library\Configuration\PlatformConfigurationHandler'
             - '@Claroline\AppBundle\API\Crud'
 
     Claroline\SamlBundle\Security\LogoutHandler:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no


New option is in `platform_options.json` and is `saml.organization_id` (the UUID of the organization to use as main organization for new users).