### PR TITLE
On release, build a docker image and publish it to ghcr.io

### DIFF
--- a/.docker/web/Dockerfile
+++ b/.docker/web/Dockerfile
@@ -48,6 +48,7 @@ COPY . /var/www/html/claroline
 WORKDIR /var/www/html/claroline
 
 RUN composer install --no-dev --optimize-autoloader
+RUN rm ./config/parameters.yml
 
 RUN npm install
 RUN npm run webpack

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -56,6 +56,7 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
+          file: ./.docker/web/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,14 +6,9 @@ name: Docker Publish
 # documentation.
 
 on:
-  schedule:
-    - cron: "30 0 * * *"
-  push:
-    branches: [docker-publish]
-    # Publish semver tags as releases.
-    tags: ["v*.*.*"]
-  pull_request:
-    branches: [docker-publish]
+  workflow_dispatch:
+  release:
+    types: [published]
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,61 @@
+name: Docker Publish
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: "30 0 * * *"
+  push:
+    branches: [docker-publish]
+    # Publish semver tags as releases.
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: [docker-publish]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,7 +3,9 @@ version: "3.7"
 services:
   web:
     container_name: claroline-web
-    image: ghcr.io/maieutiquer/claroline:docker-publish
+    build:
+      context: .
+      dockerfile: .docker/web/Dockerfile
     ports:
       - "80:80"
     volumes:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Fixed issues | no

On release, build a docker image and publish it to ghcr.io

This allows deploying Claroline from the registry:
* without building the docker image every time
* ensuring installed dependencies versions (both composer and npm) are always the same
* starting up faster because installing dependencies and building webpack is already done in the image