### PR TITLE
fixes documentation and support integration

### DIFF
--- a/src/main/core/Manager/CurlManager.php
+++ b/src/main/core/Manager/CurlManager.php
@@ -33,7 +33,7 @@ class CurlManager
             curl_setopt($ch, $option, $value);
         }
 
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 
         switch ($type) {
             case 'POST':

--- a/src/plugin/documentation/Controller/DocumentationController.php
+++ b/src/plugin/documentation/Controller/DocumentationController.php
@@ -50,7 +50,7 @@ class DocumentationController
         );
     }
 
-    private function callDocumentationApi($path, array $query = []): array
+    private function callDocumentationApi($path, array $query = []): ?array
     {
         $response = $this->curlManager->exec('https://support.claroline.com'.$path, $query, 'GET', [
             CURLOPT_HTTPHEADER => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

cURL was not configured to follow redirection. So since we've migrated `support.claroline.com`, the online documentation and our support features are broken.

I will need to update default configuration too (will require updaters).