### PR TITLE
Preserve white spaces in popover content

### DIFF
--- a/src/main/core/Resources/less/layout/components/popovers.less
+++ b/src/main/core/Resources/less/layout/components/popovers.less
@@ -22,6 +22,7 @@
 
 .popover-content {
     padding: @popover-content-padding;
+    white-space: pre;
 }
 
 .popover-list-group {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No

This PR uses `white-space: pre` to preserve the original text formatting in popover content

This fixes the issue of having no new lines in Training Price description: 

![image](https://user-images.githubusercontent.com/26501599/129694014-e8af156a-3241-4ba0-b5ab-d282b9d71ddc.png)

![image](https://user-images.githubusercontent.com/26501599/129694095-f0e333bf-1f7a-4d46-acac-dd71ce88e6ef.png)







