### PR TITLE
[Trainings] Fix line wrapping in price description tooltip

### DIFF
--- a/src/main/core/Resources/less/layout/components/popovers.less
+++ b/src/main/core/Resources/less/layout/components/popovers.less
@@ -22,7 +22,7 @@
 
 .popover-content {
     padding: @popover-content-padding;
-    white-space: pre;
+    white-space: pre-line;
 }
 
 .popover-list-group {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No

Price description before: 
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/26501599/130455603-c2351394-8f4e-4e6d-8110-cec4f4ee8812.png)

Price description after:
![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/26501599/130455611-b6cf2795-9e5a-4c4b-9e50-6f86d31fe6b2.png)


