### PR TITLE
Fix session cookie_samesite parameter for Saml

### DIFF
--- a/src/main/core/Resources/config/parameters.yml
+++ b/src/main/core/Resources/config/parameters.yml
@@ -37,3 +37,6 @@ parameters:
 
     # Geoip
     claroline.param.geoip_db_path: '%kernel.project_dir%/var/geoip/GeoLite2-City.mmdb'
+
+    # Session
+    claroline.session_cookie_samesite: lax

--- a/src/main/core/Resources/config/suggested/framework_prod.yml
+++ b/src/main/core/Resources/config/suggested/framework_prod.yml
@@ -14,7 +14,7 @@ framework:
         handler_id: "claroline.session_handler.file" # Overridden by SessionConfigPass
         cookie_httponly: true
         cookie_secure: auto
-        cookie_samesite: lax
+        cookie_samesite: "%claroline.session_cookie_samesite%"
     cache: ~
     php_errors:
         log: true

--- a/src/plugin/saml/DependencyInjection/Compiler/SamlConfigPass.php
+++ b/src/plugin/saml/DependencyInjection/Compiler/SamlConfigPass.php
@@ -25,6 +25,9 @@ class SamlConfigPass implements CompilerPassInterface
         /** @var PlatformConfigurationHandler $configHandler */
         $configHandler = $container->get(PlatformConfigurationHandler::class);
 
+        // this will allow to send the user cookie to the IDP to make redirection work
+        $container->setParameter('claroline.session_cookie_samesite', 'none');
+
         $container->setParameter('entity_id', $configHandler->getParameter('saml.entity_id'));
         $container->setParameter('lightsaml.own.entity_id', $configHandler->getParameter('saml.entity_id'));
         $container->setParameter('credentials', $configHandler->getParameter('saml.credentials'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed issues | -

Bundles configuration keys are not automatically mapped as container parameters, we need to set and use the param explicitly.
~~/!\ The `parameters.yml` file will need an update when deploying~~ (not needed anymore)
