### PR TITLE
upgrades doctrine-extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "doctrine/orm": "^2.8",
         "dompdf/dompdf": "*",
         "friendsofsymfony/jsrouting-bundle": "^2.2",
-        "gedmo/doctrine-extensions": "^3.1",
+        "gedmo/doctrine-extensions": "^3.2",
         "geoip2/geoip2": "^2.11",
         "hwi/oauth-bundle": "^1.1",
         "icap/html-diff": "1.1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

There is a problem with `doctrine/orm` v2.10 : https://github.com/doctrine-extensions/DoctrineExtensions/issues/2261.
They included it in the composer `conflict` in the 3.2