### PR TITLE
Extend length of resume on Courses & Sessions

### DIFF
--- a/src/plugin/cursus/Entity/AbstractTraining.php
+++ b/src/plugin/cursus/Entity/AbstractTraining.php
@@ -52,7 +52,7 @@ class AbstractTraining
     protected $name;
 
     /**
-     * @ORM\Column(nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      *
      * @var string
      */

--- a/src/plugin/cursus/Installation/Migrations/pdo_mysql/Version20211014084318.php
+++ b/src/plugin/cursus/Installation/Migrations/pdo_mysql/Version20211014084318.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Claroline\CursusBundle\Installation\Migrations\pdo_mysql;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated migration based on mapping information: modify it with caution.
+ *
+ * Generation date: 2021/10/14 08:43:20
+ */
+class Version20211014084318 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql("
+            ALTER TABLE claro_cursusbundle_course_session 
+            DROP used_by_quotas, 
+            DROP quota_days, 
+            CHANGE plainDescription plainDescription LONGTEXT DEFAULT NULL
+        ");
+        $this->addSql("
+            ALTER TABLE claro_cursusbundle_course CHANGE plainDescription plainDescription LONGTEXT DEFAULT NULL
+        ");
+        $this->addSql("
+            ALTER TABLE claro_cursusbundle_course_session_user 
+            DROP status, 
+            DROP remark
+        ");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("
+            ALTER TABLE claro_cursusbundle_course CHANGE plainDescription plainDescription VARCHAR(255) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`
+        ");
+        $this->addSql("
+            ALTER TABLE claro_cursusbundle_course_session 
+            ADD used_by_quotas TINYINT(1) NOT NULL, 
+            ADD quota_days DOUBLE PRECISION DEFAULT '0', 
+            CHANGE plainDescription plainDescription VARCHAR(255) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`
+        ");
+        $this->addSql("
+            ALTER TABLE claro_cursusbundle_course_session_user 
+            ADD status INT NOT NULL, 
+            ADD remark LONGTEXT CHARACTER SET utf8 NOT NULL COLLATE `utf8_unicode_ci`
+        ");
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Fixed issues | characters limit in resume on Courses & Sessions

Extend length of plainDescription in class AbstractTraining.
The modification impact the resume of entities Course and Session.

![image](https://user-images.githubusercontent.com/1777148/137286091-5ad5a256-00d7-491e-8bdc-c7e3aa901b1f.png)
![image](https://user-images.githubusercontent.com/1777148/137286031-4d734c04-98b7-4c30-a522-1efc7449af05.png)




