### PR TITLE
[Docker] Compatibility with npm 7-8 and Compose V2, fix mysql config file, fix path

### DIFF
--- a/.docker.dev/web/Dockerfile
+++ b/.docker.dev/web/Dockerfile
@@ -1,10 +1,10 @@
-FROM php:7.4-apache
+FROM php:8.0-apache
 
 LABEL maintainer="Donovan Tengblad"
 
 RUN a2enmod rewrite expires ssl headers
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
 RUN apt-get update && apt-get install -y \
   git \
   mariadb-client \
@@ -52,6 +52,8 @@ RUN a2dissite 000-default && a2dissite default-ssl && a2ensite claroline.conf
 
 COPY . /var/www/html/claroline
 WORKDIR /var/www/html/claroline
+
+RUN chmod 644 ./.docker/mysql
 
 COPY ./.docker.dev/web/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/.docker.dev/web/entrypoint.sh
+++ b/.docker.dev/web/entrypoint.sh
@@ -21,7 +21,7 @@ if [ -f files/installed ]; then
     if [[ "$versionLastUsed" != "$currentVersion" ]]; then
       echo "New version detected, updating..."
       composer install
-      npm install
+      npm install --legacy-peer-deps
       php bin/console claroline:update --env=dev -vvv
       chmod -R 777 var files config
       composer delete-cache # fixes SAML errors
@@ -32,7 +32,7 @@ if [ -f files/installed ]; then
 else
   echo "Installing Claroline..."
   composer install
-  npm install
+  npm install --legacy-peer-deps
   php bin/console claroline:install --env=dev -vvv
 
   if [[ -v PLATFORM_NAME ]]; then

--- a/.docker/web/Dockerfile
+++ b/.docker/web/Dockerfile
@@ -1,10 +1,10 @@
-FROM php:7.4-apache
+FROM php:8.0-apache
 
 LABEL maintainer="Donovan Tengblad"
 
 RUN a2enmod rewrite expires ssl headers
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
 RUN apt-get update && apt-get install -y \
   git \
   mariadb-client \
@@ -50,8 +50,10 @@ WORKDIR /var/www/html/claroline
 RUN composer install --no-dev --optimize-autoloader
 RUN rm ./config/parameters.yml
 
-RUN npm install
+RUN npm install --legacy-peer-deps
 RUN npm run webpack
+
+RUN chmod 644 ./.docker/mysql
 
 COPY ./.docker/web/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,7 +8,7 @@ name: Docker Publish
 on:
   workflow_dispatch:
   release:
-    types: [published]
+    types: [released]
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ file. For an installation from scratch, the commands would be:
     cd Claroline
     composer install --no-dev --optimize-autoloader
 
-    npm install
+    npm install (for npm 7+ you need to pass --legacy-peer-deps)
     npm run webpack
     
     php bin/console claroline:install -vvv
@@ -127,7 +127,7 @@ For a development installation, you'll need at least:
 - MySQL/MariaDB >= 8.0
 - [composer][composer] (recent version)
 - [node.js][node] >= 10
-- [npm][npm] >= 6
+- [npm][npm] >= 6 (for 7+ you need to pass --legacy-peer-deps)
 
 It's also highly recommended to develop on an UNIX-like OS.
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,7 +10,7 @@ services:
       - "80:80"
       - "8080:8080"
     volumes:
-      - ./:/var/www/html/claroline/
+      - ./:/var/www/html/claroline
     depends_on:
       - db
     environment:
@@ -18,6 +18,7 @@ services:
       - ENV=DEV
       - APP_ENV=dev
       - APP_DEBUG=1
+      - NODE_ENV=development
       - DB_HOST=claroline-db
       - DB_NAME=claroline
       - DB_USER=claroline
@@ -42,12 +43,11 @@ services:
       MYSQL_PASSWORD: claroline
       MYSQL_DATABASE: claroline
     image: mysql:8.0
-    command: --sql_mode="" --default_authentication_plugin="mysql_native_password"
     ports:
       - "3306:3306"
     volumes:
       - ../mysql:/var/lib/mysql
-      - ./.docker.dev/mysql:/etc/mysql/conf.d # TODO check why is world-writable config file ignored, shall we make it read-only? When and how?
+      - ./.docker.dev/mysql:/etc/mysql/conf.d
     networks:
       claroline_network:
         ipv4_address: 172.22.9.5

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,9 +3,7 @@ version: "3.7"
 services:
   web:
     container_name: claroline-web
-    build:
-      context: .
-      dockerfile: .docker/web/Dockerfile
+    image: ghcr.io/claroline/claroline:13.x
     ports:
       - "80:80"
     volumes:
@@ -22,6 +20,7 @@ services:
       - ENV=PROD
       - APP_ENV=prod
       - APP_DEBUG=0
+      - NODE_ENV=production
       - DB_HOST=claroline-db
       - DB_NAME=claroline
       - DB_USER=claroline
@@ -46,12 +45,11 @@ services:
       MYSQL_PASSWORD: claroline
       MYSQL_DATABASE: claroline
     image: mysql:8.0
-    command: --sql_mode="" --default_authentication_plugin="mysql_native_password"
     ports:
       - "3306:3306"
     volumes:
       - ../mysql:/var/lib/mysql
-      - ./.docker/mysql:/etc/mysql/conf.d # TODO check why is world-writable config file ignored, shall we make it read-only? When and how?
+      - ./.docker/mysql:/etc/mysql/conf.d
     networks:
       claroline_network:
         ipv4_address: 172.22.9.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@ version: "3.7"
 services:
   web:
     container_name: claroline-web
-    image: ghcr.io/maieutiquer/claroline:docker-publish
+    build:
+      context: .
+      dockerfile: .docker/web/Dockerfile
     ports:
       - "80:80"
     volumes:
@@ -20,6 +22,7 @@ services:
       - ENV=PROD
       - APP_ENV=prod
       - APP_DEBUG=0
+      - NODE_ENV=production
       - DB_HOST=claroline-db
       - DB_NAME=claroline
       - DB_USER=claroline
@@ -44,12 +47,11 @@ services:
       MYSQL_PASSWORD: claroline
       MYSQL_DATABASE: claroline
     image: mysql:8.0
-    command: --sql_mode="" --default_authentication_plugin="mysql_native_password"
     ports:
       - "3306:3306"
     volumes:
       - ../mysql:/var/lib/mysql
-      - ./.docker/mysql:/etc/mysql/conf.d # TODO check why is world-writable config file ignored, shall we make it read-only? When and how?
+      - ./.docker/mysql:/etc/mysql/conf.d
     networks:
       claroline_network:
         ipv4_address: 172.22.9.5


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

- fix compatibility with npm 7 and npm 8 by adding the `--legacy-peer-deps` flag
- fix mysql config file not taken into account and cleanup redundant command flag in compose files
- fix docker image path - it was mistakenly pointing to another repo
- try fixing the docker image package build, triggered on release of a new version