### PR TITLE
[Evaluation] adds data sources

### DIFF
--- a/src/main/app/Resources/modules/content/list/containers/source.jsx
+++ b/src/main/app/Resources/modules/content/list/containers/source.jsx
@@ -60,11 +60,11 @@ const ListSource = props => {
       card={computedCard}
       display={{
         current: props.parameters.display,
-        available: props.parameters.availableDisplays
+        available: !isEmpty(props.parameters.availableDisplays) ? props.parameters.availableDisplays : [props.parameters.display]
       }}
       searchMode={get(props.parameters, 'searchMode') || undefined}
       pageSizes={get(props.parameters, 'availablePageSizes') || undefined}
-      count={isEmpty(props.parameters) || props.parameters.count}
+      count={get(props.parameters, 'count', false)}
       selectable={get(props.parameters, 'actions', false) && !!get(props.source, 'parameters.actions')}
       filterable={isEmpty(props.parameters) || !isEmpty(props.parameters.availableFilters)}
       sortable={isEmpty(props.parameters) || !isEmpty(props.parameters.availableSort)}

--- a/src/main/app/Resources/modules/content/list/parameters/components/form.jsx
+++ b/src/main/app/Resources/modules/content/list/parameters/components/form.jsx
@@ -394,7 +394,8 @@ const ListForm = props => {
           displayed: (parameters) => {
             const availableDisplays = get(parameters, 'availableDisplays') || []
 
-            return !!availableDisplays.find(displayMode => constants.DISPLAY_MODES[displayMode].options.filterColumns)
+            return (parameters.display && constants.DISPLAY_MODES[parameters.display].options.filterColumns)
+              || !!availableDisplays.find(displayMode => constants.DISPLAY_MODES[displayMode].options.filterColumns)
           },
           fields: [
             {

--- a/src/main/authentication/Resources/translations/data_sources.fr.json
+++ b/src/main/authentication/Resources/translations/data_sources.fr.json
@@ -1,4 +1,4 @@
 {
-  "my_tokens": "Liste de mes jestons d'authentications",
+  "my_tokens": "Liste de mes jetons d'authentications",
   "my_tokens_desc": "Permet de lister les jetons d'authentications de l'utilisateur courant."
 }

--- a/src/main/evaluation/Finder/ResourceEvaluationFinder.php
+++ b/src/main/evaluation/Finder/ResourceEvaluationFinder.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\EvaluationBundle\Finder;
+
+use Claroline\AppBundle\API\Finder\AbstractFinder;
+use Claroline\CoreBundle\Entity\Resource\ResourceEvaluation;
+use Doctrine\ORM\QueryBuilder;
+
+class ResourceEvaluationFinder extends AbstractFinder
+{
+    public static function getClass(): string
+    {
+        return ResourceEvaluation::class;
+    }
+
+    public function configureQueryBuilder(
+        QueryBuilder $qb,
+        array $searches = [],
+        array $sortBy = null,
+        array $options = ['count' => false, 'page' => 0, 'limit' => -1]
+    ) {
+        $userJoin = false;
+        $nodeJoin = false;
+
+        $qb->join('obj.resourceUserEvaluation', 'ru');
+
+        if (!array_key_exists('user', $searches)) {
+            // don't show evaluation of disabled/deleted users
+            $qb->join('ru.user', 'u');
+            $userJoin = true;
+
+            $qb->andWhere('u.isEnabled = TRUE');
+            $qb->andWhere('u.isRemoved = FALSE');
+        }
+
+        foreach ($searches as $filterName => $filterValue) {
+            switch ($filterName) {
+                case 'user':
+                    if (!$userJoin) {
+                        $qb->join('ru.user', 'u');
+                        $userJoin = true;
+                    }
+                    $qb->andWhere("u.uuid = :{$filterName}");
+                    $qb->setParameter($filterName, $filterValue);
+                    break;
+                case 'resourceNode':
+                    if (!$nodeJoin) {
+                        $qb->join('ru.resourceNode', 'r');
+                        $nodeJoin = true;
+                    }
+
+                    $qb->andWhere("r.uuid = :{$filterName}");
+                    $qb->setParameter($filterName, $filterValue);
+                    break;
+                case 'workspace':
+                    if (!$nodeJoin) {
+                        $qb->join('ru.resourceNode', 'r');
+                        $nodeJoin = true;
+                    }
+
+                    $qb->join('r.workspace', 'w');
+                    $qb->andWhere("w.uuid = :{$filterName}");
+                    $qb->setParameter($filterName, $filterValue);
+                    break;
+                default:
+                    $this->setDefaults($qb, $filterName, $filterValue);
+                    break;
+            }
+        }
+
+        return $qb;
+    }
+}

--- a/src/main/evaluation/Resources/config/config.yml
+++ b/src/main/evaluation/Resources/config/config.yml
@@ -1,1 +1,16 @@
-plugin: ~
+plugin:
+    data_sources:
+        - name: resource_attempts
+          type: list
+          context: [ workspace, desktop ]
+          tags: [ content ]
+
+        - name: resource_evaluations
+          type: list
+          context: [ workspace, desktop ]
+          tags: [ content ]
+
+        - name: workspace_evaluations
+          type: list
+          context: [ workspace, desktop ]
+          tags: [ content ]

--- a/src/main/evaluation/Resources/config/services/finder.yml
+++ b/src/main/evaluation/Resources/config/services/finder.yml
@@ -22,4 +22,6 @@ services:
 
     Claroline\EvaluationBundle\Finder\WorkspaceRequirementsFinder: ~
 
+    Claroline\EvaluationBundle\Finder\ResourceEvaluationFinder: ~
+
     Claroline\EvaluationBundle\Finder\ResourceUserEvaluationFinder: ~

--- a/src/main/evaluation/Resources/config/services/serializer.yml
+++ b/src/main/evaluation/Resources/config/services/serializer.yml
@@ -13,3 +13,6 @@ services:
 
     Claroline\EvaluationBundle\Serializer\ResourceEvaluationSerializer:
         tags: [ claroline.serializer ]
+        arguments:
+            - '@Claroline\CoreBundle\API\Serializer\Resource\ResourceNodeSerializer'
+            - '@Claroline\CoreBundle\API\Serializer\User\UserSerializer'

--- a/src/main/evaluation/Resources/config/services/subscriber.yml
+++ b/src/main/evaluation/Resources/config/services/subscriber.yml
@@ -18,3 +18,28 @@ services:
             - '@Claroline\AppBundle\Persistence\ObjectManager'
         tags:
             - { name: kernel.event_subscriber }
+
+    # Data sources
+    Claroline\EvaluationBundle\Subscriber\DataSource\ResourceAttemptSource:
+        arguments:
+            - '@security.token_storage'
+            - '@security.authorization_checker'
+            - '@Claroline\AppBundle\API\FinderProvider'
+        tags:
+            - { name: kernel.event_subscriber }
+
+    Claroline\EvaluationBundle\Subscriber\DataSource\ResourceEvaluationSource:
+        arguments:
+            - '@security.token_storage'
+            - '@security.authorization_checker'
+            - '@Claroline\AppBundle\API\FinderProvider'
+        tags:
+            - { name: kernel.event_subscriber }
+
+    Claroline\EvaluationBundle\Subscriber\DataSource\WorkspaceEvaluationSource:
+        arguments:
+            - '@security.token_storage'
+            - '@security.authorization_checker'
+            - '@Claroline\AppBundle\API\FinderProvider'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/main/evaluation/Resources/modules/data/sources/resource-attempts.js
+++ b/src/main/evaluation/Resources/modules/data/sources/resource-attempts.js
@@ -1,0 +1,69 @@
+import {trans} from '#/main/app/intl/translation'
+
+import {constants} from '#/main/core/resource/constants'
+
+export default {
+  name: 'resource_attempts',
+  parameters: {
+    definition: [
+      {
+        name: 'user',
+        type: 'user',
+        label: trans('user'),
+        displayed: true
+      }, {
+        name: 'resourceNode',
+        type: 'resource',
+        label: trans('resource'),
+        displayed: true
+      }, {
+        name: 'date',
+        label: trans('date'),
+        type: 'date',
+        options: {time: true},
+        displayed: true,
+        primary: true
+      }, {
+        name: 'status',
+        type: 'choice',
+        label: trans('status'),
+        options: {
+          choices: constants.EVALUATION_STATUSES
+        },
+        displayed: true
+      }, {
+        name: 'duration',
+        type: 'time',
+        label: trans('duration'),
+        displayed: true,
+        filterable: false
+      }, {
+        name: 'progression',
+        label: trans('progression'),
+        type: 'progression',
+        displayed: true,
+        filterable: false,
+        calculated: (rowData) => rowData.progression && rowData.progressionMax ? Math.round((rowData.progression / rowData.progressionMax) * 100) : 0,
+        options: {
+          type: 'user'
+        }
+      }, {
+        name: 'score',
+        type: 'score',
+        label: trans('score'),
+        calculated: (row) => {
+          if (row.scoreMax) {
+            return {
+              current: row.score,
+              total: row.scoreMax
+            }
+          }
+
+          return null
+        },
+        displayed: true,
+        filterable: false
+      }
+    ]
+  }
+}

--- a/src/main/evaluation/Resources/modules/data/sources/resource-evaluations.js
+++ b/src/main/evaluation/Resources/modules/data/sources/resource-evaluations.js
@@ -1,0 +1,69 @@
+import {trans} from '#/main/app/intl/translation'
+
+import {constants} from '#/main/core/resource/constants'
+
+export default {
+  name: 'resource_evaluations',
+  parameters: {
+    definition: [
+      {
+        name: 'user',
+        type: 'user',
+        label: trans('user'),
+        displayed: true
+      }, {
+        name: 'resourceNode',
+        type: 'resource',
+        label: trans('resource'),
+        displayed: true
+      }, {
+        name: 'date',
+        label: trans('date'),
+        type: 'date',
+        options: {time: true},
+        displayed: true,
+        primary: true
+      }, {
+        name: 'status',
+        type: 'choice',
+        label: trans('status'),
+        options: {
+          choices: constants.EVALUATION_STATUSES
+        },
+        displayed: true
+      }, {
+        name: 'duration',
+        type: 'time',
+        label: trans('duration'),
+        displayed: true,
+        filterable: false
+      }, {
+        name: 'progression',
+        label: trans('progression'),
+        type: 'progression',
+        displayed: true,
+        filterable: false,
+        calculated: (rowData) => rowData.progression && rowData.progressionMax ? Math.round((rowData.progression / rowData.progressionMax) * 100) : 0,
+        options: {
+          type: 'user'
+        }
+      }, {
+        name: 'score',
+        type: 'score',
+        label: trans('score'),
+        calculated: (row) => {
+          if (row.scoreMax) {
+            return {
+              current: row.score,
+              total: row.scoreMax
+            }
+          }
+
+          return null
+        },
+        displayed: true,
+        filterable: false
+      }
+    ]
+  }
+}

--- a/src/main/evaluation/Resources/modules/data/sources/workspace-evaluations.js
+++ b/src/main/evaluation/Resources/modules/data/sources/workspace-evaluations.js
@@ -1,0 +1,69 @@
+import {trans} from '#/main/app/intl/translation'
+
+import {constants} from '#/main/core/resource/constants'
+
+export default {
+  name: 'workspace_evaluations',
+  parameters: {
+    definition: [
+      {
+        name: 'user',
+        type: 'user',
+        label: trans('user'),
+        displayed: true
+      }, {
+        name: 'workspace',
+        type: 'workspace',
+        label: trans('workspace'),
+        displayed: true
+      }, {
+        name: 'date',
+        label: trans('date'),
+        type: 'date',
+        options: {time: true},
+        displayed: true,
+        primary: true
+      }, {
+        name: 'status',
+        type: 'choice',
+        label: trans('status'),
+        options: {
+          choices: constants.EVALUATION_STATUSES
+        },
+        displayed: true
+      }, {
+        name: 'duration',
+        type: 'time',
+        label: trans('duration'),
+        displayed: true,
+        filterable: false
+      }, {
+        name: 'progression',
+        label: trans('progression'),
+        type: 'progression',
+        displayed: true,
+        filterable: false,
+        calculated: (rowData) => rowData.progression && rowData.progressionMax ? Math.round((rowData.progression / rowData.progressionMax) * 100) : 0,
+        options: {
+          type: 'user'
+        }
+      }, {
+        name: 'score',
+        type: 'score',
+        label: trans('score'),
+        calculated: (row) => {
+          if (row.scoreMax) {
+            return {
+              current: row.score,
+              total: row.scoreMax
+            }
+          }
+
+          return null
+        },
+        displayed: true,
+        filterable: false
+      }
+    ]
+  }
+}

--- a/src/main/evaluation/Resources/modules/plugin.js
+++ b/src/main/evaluation/Resources/modules/plugin.js
@@ -1,0 +1,16 @@
+/* eslint-disable */
+
+import {registry} from '#/main/app/plugins/registry'
+
+/**
+ * Declares applications provided by the Evaluation plugin.
+ */
+registry.add('ClarolineEvaluationBundle', {
+  data: {
+    sources: {
+      'resource_attempts'    : () => { return import(/* webpackChunkName: "evaluation-source-resource_attempts" */     '#/main/evaluation/data/sources/resource-attempts') },
+      'resource_evaluations' : () => { return import(/* webpackChunkName: "evaluation-source-resource_evaluations" */  '#/main/evaluation/data/sources/resource-evaluations') },
+      'workspace_evaluations': () => { return import(/* webpackChunkName: "evaluation-source-workspace_evaluations" */ '#/main/evaluation/data/sources/workspace-evaluations') }
+    }
+  }
+})

--- a/src/main/evaluation/Resources/translations/data_sources.en.json
+++ b/src/main/evaluation/Resources/translations/data_sources.en.json
@@ -1,0 +1,8 @@
+{
+  "resource_attempts": "List of resources attempts",
+  "resource_attempts_desc": "Allows to list the attempts made by users.",
+  "resource_evaluations": "List of resources evaluations",
+  "resource_evaluations_desc": "Allows to list the evaluations obtained by users for resources.",
+  "workspace_evaluations": "List of workspaces evaluations",
+  "workspace_evaluations_desc": "Allows to list the evaluations obtained by users for workspaces."
+}

--- a/src/main/evaluation/Resources/translations/data_sources.fr.json
+++ b/src/main/evaluation/Resources/translations/data_sources.fr.json
@@ -1,0 +1,8 @@
+{
+  "resource_attempts": "Liste des tentatives aux ressources",
+  "resource_attempts_desc": "Permet de lister les tentatives effectuées par les utilisateurs.",
+  "resource_evaluations": "Liste des évaluations des ressources",
+  "resource_evaluations_desc": "Permet de lister les évaluations obtenues par les utilisateurs pour des ressources.",
+  "workspace_evaluations": "Liste des évaluations des espaces d'activités",
+  "workspace_evaluations_desc": "Permet de lister les évaluations obtenues par les utilisateurs pour des espaces d'activités."
+}

--- a/src/main/evaluation/Serializer/ResourceEvaluationSerializer.php
+++ b/src/main/evaluation/Serializer/ResourceEvaluationSerializer.php
@@ -3,11 +3,24 @@
 namespace Claroline\EvaluationBundle\Serializer;
 
 use Claroline\AppBundle\API\Options;
+use Claroline\CoreBundle\API\Serializer\Resource\ResourceNodeSerializer;
+use Claroline\CoreBundle\API\Serializer\User\UserSerializer;
 use Claroline\CoreBundle\Entity\Resource\ResourceEvaluation;
 use Claroline\CoreBundle\Library\Normalizer\DateNormalizer;
 
 class ResourceEvaluationSerializer
 {
+    /** @var ResourceNodeSerializer */
+    private $resourceNodeSerializer;
+    /** @var UserSerializer */
+    private $userSerializer;
+
+    public function __construct(ResourceNodeSerializer $resourceNodeSerializer, UserSerializer $userSerializer)
+    {
+        $this->resourceNodeSerializer = $resourceNodeSerializer;
+        $this->userSerializer = $userSerializer;
+    }
+
     public function getName(): string
     {
         return 'resource_evaluation';
@@ -38,9 +51,15 @@ class ResourceEvaluationSerializer
         ];
 
         if (!in_array(Options::SERIALIZE_MINIMAL, $options)) {
+            $resourceUserEvaluation = $resourceEvaluation->getResourceUserEvaluation();
+
             $serialized = array_merge($serialized, [
                 'comment' => $resourceEvaluation->getComment(),
                 'data' => $resourceEvaluation->getData(),
+
+                // used by data source, this may require another option to avoid getting it where we don't want it
+                'resourceNode' => $this->resourceNodeSerializer->serialize($resourceUserEvaluation->getResourceNode(), [Options::SERIALIZE_MINIMAL]),
+                'user' => $this->userSerializer->serialize($resourceUserEvaluation->getUser(), [Options::SERIALIZE_MINIMAL]),
             ]);
         }
 

--- a/src/main/evaluation/Subscriber/DataSource/ResourceAttemptSource.php
+++ b/src/main/evaluation/Subscriber/DataSource/ResourceAttemptSource.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Claroline\EvaluationBundle\Subscriber\DataSource;
+
+use Claroline\AppBundle\API\FinderProvider;
+use Claroline\CoreBundle\Entity\DataSource;
+use Claroline\CoreBundle\Entity\Resource\ResourceEvaluation;
+use Claroline\CoreBundle\Entity\User;
+use Claroline\CoreBundle\Event\DataSource\GetDataEvent;
+use Claroline\CoreBundle\Security\PlatformRoles;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+class ResourceAttemptSource implements EventSubscriberInterface
+{
+    /** @var TokenStorageInterface */
+    private $tokenStorage;
+    /** @var AuthorizationCheckerInterface */
+    private $authorization;
+    /** @var FinderProvider */
+    private $finder;
+
+    public function __construct(
+        TokenStorageInterface $tokenStorage,
+        AuthorizationCheckerInterface $authorization,
+        FinderProvider $finder
+    ) {
+        $this->tokenStorage = $tokenStorage;
+        $this->authorization = $authorization;
+        $this->finder = $finder;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'data_source.resource_attempts.load' => 'getData',
+        ];
+    }
+
+    public function getData(GetDataEvent $event)
+    {
+        /** @var User $currentUser */
+        $currentUser = $this->tokenStorage->getToken()->getUser();
+
+        $options = $event->getOptions();
+        if (DataSource::CONTEXT_WORKSPACE === $event->getContext()) {
+            $workspace = $event->getWorkspace();
+
+            $options['hiddenFilters']['workspace'] = $workspace->getUuid();
+            if (!$this->authorization->isGranted('ADMINISTRATE', $workspace)) {
+                $options['hiddenFilters']['user'] = $currentUser->getUuid();
+            }
+        } elseif (!$this->authorization->isGranted(PlatformRoles::ADMIN)) {
+            // desktop
+            $options['hiddenFilters']['user'] = $currentUser->getUuid();
+        }
+
+        $event->setData(
+            $this->finder->search(ResourceEvaluation::class, $options)
+        );
+
+        $event->stopPropagation();
+    }
+}

--- a/src/main/evaluation/Subscriber/DataSource/ResourceEvaluationSource.php
+++ b/src/main/evaluation/Subscriber/DataSource/ResourceEvaluationSource.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Claroline\EvaluationBundle\Subscriber\DataSource;
+
+use Claroline\AppBundle\API\FinderProvider;
+use Claroline\CoreBundle\Entity\DataSource;
+use Claroline\CoreBundle\Entity\Resource\ResourceUserEvaluation;
+use Claroline\CoreBundle\Entity\User;
+use Claroline\CoreBundle\Event\DataSource\GetDataEvent;
+use Claroline\CoreBundle\Security\PlatformRoles;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+class ResourceEvaluationSource implements EventSubscriberInterface
+{
+    /** @var TokenStorageInterface */
+    private $tokenStorage;
+    /** @var AuthorizationCheckerInterface */
+    private $authorization;
+    /** @var FinderProvider */
+    private $finder;
+
+    public function __construct(
+        TokenStorageInterface $tokenStorage,
+        AuthorizationCheckerInterface $authorization,
+        FinderProvider $finder
+    ) {
+        $this->tokenStorage = $tokenStorage;
+        $this->authorization = $authorization;
+        $this->finder = $finder;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'data_source.resource_evaluations.load' => 'getData',
+        ];
+    }
+
+    public function getData(GetDataEvent $event)
+    {
+        /** @var User $currentUser */
+        $currentUser = $this->tokenStorage->getToken()->getUser();
+
+        $options = $event->getOptions();
+        if (DataSource::CONTEXT_WORKSPACE === $event->getContext()) {
+            $workspace = $event->getWorkspace();
+
+            $options['hiddenFilters']['workspace'] = $workspace->getUuid();
+            if (!$this->authorization->isGranted('ADMINISTRATE', $workspace)) {
+                $options['hiddenFilters']['user'] = $currentUser->getUuid();
+            }
+        } elseif (!$this->authorization->isGranted(PlatformRoles::ADMIN)) {
+            // desktop
+            $options['hiddenFilters']['user'] = $currentUser->getUuid();
+        }
+
+        $event->setData(
+            $this->finder->search(ResourceUserEvaluation::class, $options)
+        );
+
+        $event->stopPropagation();
+    }
+}

--- a/src/main/evaluation/Subscriber/DataSource/WorkspaceEvaluationSource.php
+++ b/src/main/evaluation/Subscriber/DataSource/WorkspaceEvaluationSource.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Claroline\EvaluationBundle\Subscriber\DataSource;
+
+use Claroline\AppBundle\API\FinderProvider;
+use Claroline\CoreBundle\Entity\DataSource;
+use Claroline\CoreBundle\Entity\User;
+use Claroline\CoreBundle\Entity\Workspace\Evaluation;
+use Claroline\CoreBundle\Event\DataSource\GetDataEvent;
+use Claroline\CoreBundle\Security\PlatformRoles;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+class WorkspaceEvaluationSource implements EventSubscriberInterface
+{
+    /** @var TokenStorageInterface */
+    private $tokenStorage;
+    /** @var AuthorizationCheckerInterface */
+    private $authorization;
+    /** @var FinderProvider */
+    private $finder;
+
+    public function __construct(
+        TokenStorageInterface $tokenStorage,
+        AuthorizationCheckerInterface $authorization,
+        FinderProvider $finder
+    ) {
+        $this->tokenStorage = $tokenStorage;
+        $this->authorization = $authorization;
+        $this->finder = $finder;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'data_source.workspace_evaluations.load' => 'getData',
+        ];
+    }
+
+    public function getData(GetDataEvent $event)
+    {
+        /** @var User $currentUser */
+        $currentUser = $this->tokenStorage->getToken()->getUser();
+
+        $options = $event->getOptions();
+        if (DataSource::CONTEXT_WORKSPACE === $event->getContext()) {
+            $workspace = $event->getWorkspace();
+
+            $options['hiddenFilters']['workspace'] = $workspace->getUuid();
+            if (!$this->authorization->isGranted('ADMINISTRATE', $workspace)) {
+                $options['hiddenFilters']['user'] = $currentUser->getUuid();
+            }
+        } elseif (!$this->authorization->isGranted(PlatformRoles::ADMIN)) {
+            // desktop
+            $options['hiddenFilters']['user'] = $currentUser->getUuid();
+        }
+
+        $event->setData(
+            $this->finder->search(Evaluation::class, $options)
+        );
+
+        $event->stopPropagation();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no

Adds new data sources for : 
- Resource attempts
- Resource evaluations
- Workspace evaluations

All new sources are available for the `desktop` and `workspace` context.

On desktop, users with `ROLE_ADMIN` role see all, others see theirs.
On workspace, users with `ADMINISTRATE` right see all, others see theirs.

We might change it later to check the `ADMINISTRATE` or `EDIT` right on the future evaluation tool.
