### PR TITLE
[Template] replaces mysql reserved keyword in entity prop

### DIFF
--- a/src/main/core/Entity/Template/Template.php
+++ b/src/main/core/Entity/Template/Template.php
@@ -44,7 +44,7 @@ class Template
      * System templates can not be edited nor deleted by users.
      * They are managed through DataFixtures.
      *
-     * @ORM\Column(type="boolean")
+     * @ORM\Column(name="is_system", type="boolean")
      *
      * @var bool
      */

--- a/src/main/core/Installation/Migrations/pdo_mysql/Version20211026053317.php
+++ b/src/main/core/Installation/Migrations/pdo_mysql/Version20211026053317.php
@@ -71,7 +71,7 @@ class Version20211026053317 extends AbstractMigration
 
         $this->addSql('
             ALTER TABLE claro_template 
-            DROP system
+            DROP `system`
         ');
     }
 }

--- a/src/main/core/Installation/Migrations/pdo_mysql/Version20211125072427.php
+++ b/src/main/core/Installation/Migrations/pdo_mysql/Version20211125072427.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Claroline\CoreBundle\Installation\Migrations\pdo_mysql;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated migration based on mapping information: modify it with caution.
+ *
+ * Generation date: 2021/11/25 07:24:33
+ */
+class Version20211125072427 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('
+            ALTER TABLE claro_template CHANGE `system` is_system TINYINT(1) NOT NULL
+        ');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('
+            ALTER TABLE claro_template CHANGE is_system system TINYINT(1) NOT NULL
+        ');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

In MySQL >= 8.0.3 and MariaDB >= MariaDB 10.3.6, `system` is a reserved keyword and is not well escaped by Doctrine causing crashes in those environments.

ping @maieutiquer 
