### PR TITLE
[Theme] Fix fonts folder not being copied

### DIFF
--- a/src/main/core/Resources/server/themes/build.js
+++ b/src/main/core/Resources/server/themes/build.js
@@ -63,7 +63,9 @@ function buildTheme(theme, themeState) {
           // src
           path.resolve(theme.location, theme.name, assetDir),
           // destination
-          path.resolve(themeDir))
+          path.resolve(themeDir),
+          // asset dir
+          assetDir)
       )
     }
 
@@ -141,11 +143,14 @@ function createAsset(asset, outputFile, currentVersion, globalVars) {
  * Recursively copies static files directories (eg. images, fonts)
  * @param {string} src
  * @param {string} destination
+ * @param {string} assetDir
  */
-function copyStatic(src, destination) {
-  console.log(src)
-  console.log(destination)
-  shell.rm('-rf', destination)
+function copyStatic(src, destination, assetDir) {
+  const pathToRemove = path.join(destination, assetDir)
+  console.log('Removing path: ', pathToRemove)
+  console.log('copy src: ', src)
+  console.log('copy destination: ', destination)
+  shell.rm('-rf', pathToRemove)
   shell.cp('-R', src, destination)
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed issues | #1954

We are now deleting only the current resource folder before copying it, not the entire theme folder


