### PR TITLE
[Community] fixes role and group access rights

### DIFF
--- a/src/main/core/Security/Voter/RoleVoter.php
+++ b/src/main/core/Security/Voter/RoleVoter.php
@@ -26,11 +26,20 @@ class RoleVoter extends AbstractVoter
         return Role::class;
     }
 
+    /**
+     * @param Role $object
+     */
     public function checkPermission(TokenInterface $token, $object, array $attributes, array $options)
     {
         $collection = isset($options['collection']) ? $options['collection'] : null;
 
         switch ($attributes[0]) {
+            case self::OPEN:
+                if (in_array($object->getName(), $token->getRoleNames())) {
+                    return VoterInterface::ACCESS_GRANTED;
+                }
+
+                return VoterInterface::ACCESS_DENIED;
             case self::EDIT:
                 return $this->check($token, $object);
             case self::PATCH:
@@ -109,6 +118,6 @@ class RoleVoter extends AbstractVoter
 
     public function getSupportedActions()
     {
-        return [self::CREATE, self::EDIT, self::DELETE, self::PATCH];
+        return [self::CREATE, self::OPEN, self::EDIT, self::DELETE, self::PATCH];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

I've closed some endpoints in the last version which caused standard users can't see team members.
It uses the list of users for the member role which is now closed by the `OPEN` right on the role.

The `RoleVoter` has been updated to give this right to the owners of the role. I've updated the `GroupVoter` to make it work the same way.