### PR TITLE
allows to filter on disabled users

### DIFF
--- a/src/main/core/Resources/modules/tools/community/user/components/users.jsx
+++ b/src/main/core/Resources/modules/tools/community/user/components/users.jsx
@@ -92,6 +92,14 @@ const UsersList = props =>
             filters: []
           } : undefined
         }
+      }, {
+        name: 'restrictions.disabled',
+        alias: 'isDisabled',
+        type: 'boolean',
+        label: trans('disabled'),
+        displayable: false,
+        sortable: false,
+        filterable: true
       }
     ]}
     card={UserCard}

--- a/src/main/evaluation/Finder/ResourceUserEvaluationFinder.php
+++ b/src/main/evaluation/Finder/ResourceUserEvaluationFinder.php
@@ -31,7 +31,7 @@ class ResourceUserEvaluationFinder extends AbstractFinder
         $userJoin = false;
         $nodeJoin = false;
 
-        if (!array_key_exists('user', $searches)) {
+        if (!array_key_exists('userDisabled', $searches) && !array_key_exists('user', $searches)) {
             // don't show evaluation of disabled/deleted users
             $qb->join('obj.user', 'u');
             $userJoin = true;
@@ -49,6 +49,15 @@ class ResourceUserEvaluationFinder extends AbstractFinder
                     }
                     $qb->andWhere("u.uuid = :{$filterName}");
                     $qb->setParameter($filterName, $filterValue);
+                    break;
+                case 'userDisabled':
+                    if (!$userJoin) {
+                        $qb->join('obj.user', 'u');
+                        $userJoin = true;
+                    }
+                    $qb->andWhere('u.isEnabled = :isEnabled');
+                    $qb->andWhere('u.isRemoved = FALSE');
+                    $qb->setParameter('isEnabled', !$filterValue);
                     break;
                 case 'user.firstName':
                     if (!$userJoin) {

--- a/src/main/evaluation/Finder/WorkspaceEvaluationFinder.php
+++ b/src/main/evaluation/Finder/WorkspaceEvaluationFinder.php
@@ -29,7 +29,7 @@ class WorkspaceEvaluationFinder extends AbstractFinder
         array $options = ['count' => false, 'page' => 0, 'limit' => -1]
     ) {
         $userJoin = false;
-        if (!array_key_exists('user', $searches)) {
+        if (!array_key_exists('userDisabled', $searches) && !array_key_exists('user', $searches)) {
             // don't show evaluation of disabled/deleted users
             $qb->join('obj.user', 'u');
             $userJoin = true;
@@ -69,6 +69,15 @@ class WorkspaceEvaluationFinder extends AbstractFinder
 
                     $qb->andWhere("u.uuid = :{$filterName}");
                     $qb->setParameter($filterName, $filterValue);
+                    break;
+                case 'userDisabled':
+                    if (!$userJoin) {
+                        $qb->join('obj.user', 'u');
+                        $userJoin = true;
+                    }
+                    $qb->andWhere('u.isEnabled = :isEnabled');
+                    $qb->andWhere('u.isRemoved = FALSE');
+                    $qb->setParameter('isEnabled', !$filterValue);
                     break;
                 default:
                     $this->setDefaults($qb, $filterName, $filterValue);

--- a/src/main/evaluation/Resources/modules/data/sources/resource-evaluations.js
+++ b/src/main/evaluation/Resources/modules/data/sources/resource-evaluations.js
@@ -63,6 +63,13 @@ export default {
         },
         displayed: true,
         filterable: false
+      }, {
+        name: 'userDisabled',
+        label: trans('user_disabled'),
+        type: 'boolean',
+        displayable: false,
+        sortable: false,
+        filterable: true
       }
     ]
   }

--- a/src/main/evaluation/Resources/modules/data/sources/workspace-evaluations.js
+++ b/src/main/evaluation/Resources/modules/data/sources/workspace-evaluations.js
@@ -63,6 +63,13 @@ export default {
         },
         displayed: true,
         filterable: false
+      }, {
+        name: 'userDisabled',
+        label: trans('user_disabled'),
+        type: 'boolean',
+        displayable: false,
+        sortable: false,
+        filterable: true
       }
     ]
   }

--- a/src/main/evaluation/Resources/modules/tools/evaluation/components/users.jsx
+++ b/src/main/evaluation/Resources/modules/tools/evaluation/components/users.jsx
@@ -105,6 +105,13 @@ const EvaluationUsers = (props) =>
           },
           displayed: true,
           filterable: false
+        }, {
+          name: 'userDisabled',
+          label: trans('user_disabled'),
+          type: 'boolean',
+          displayable: false,
+          sortable: false,
+          filterable: true
         }
       ]}
       actions={(rows) => [

--- a/src/plugin/cursus/Finder/Registration/CourseUserFinder.php
+++ b/src/plugin/cursus/Finder/Registration/CourseUserFinder.php
@@ -25,6 +25,14 @@ class CourseUserFinder extends AbstractFinder
     public function configureQueryBuilder(QueryBuilder $qb, array $searches = [], array $sortBy = null, array $options = ['count' => false, 'page' => 0, 'limit' => -1])
     {
         $userJoin = false;
+        if (!array_key_exists('userDisabled', $searches) && !array_key_exists('user', $searches)) {
+            // don't show registrations of disabled/deleted users
+            $qb->join('obj.user', 'u');
+            $userJoin = true;
+
+            $qb->andWhere('u.isEnabled = TRUE');
+            $qb->andWhere('u.isRemoved = FALSE');
+        }
 
         foreach ($searches as $filterName => $filterValue) {
             switch ($filterName) {
@@ -42,6 +50,16 @@ class CourseUserFinder extends AbstractFinder
 
                     $qb->andWhere("u.uuid = :{$filterName}");
                     $qb->setParameter($filterName, $filterValue);
+                    break;
+
+                case 'userDisabled':
+                    if (!$userJoin) {
+                        $qb->join('obj.user', 'u');
+                        $userJoin = true;
+                    }
+                    $qb->andWhere('u.isEnabled = :isEnabled');
+                    $qb->andWhere('u.isRemoved = FALSE');
+                    $qb->setParameter('isEnabled', !$filterValue);
                     break;
 
                 case 'organizations':

--- a/src/plugin/cursus/Finder/Registration/EventUserFinder.php
+++ b/src/plugin/cursus/Finder/Registration/EventUserFinder.php
@@ -25,6 +25,14 @@ class EventUserFinder extends AbstractFinder
     public function configureQueryBuilder(QueryBuilder $qb, array $searches = [], array $sortBy = null, array $options = ['count' => false, 'page' => 0, 'limit' => -1])
     {
         $userJoin = false;
+        if (!array_key_exists('userDisabled', $searches) && !array_key_exists('user', $searches)) {
+            // don't show registrations of disabled/deleted users
+            $qb->join('obj.user', 'u');
+            $userJoin = true;
+
+            $qb->andWhere('u.isEnabled = TRUE');
+            $qb->andWhere('u.isRemoved = FALSE');
+        }
 
         foreach ($searches as $filterName => $filterValue) {
             switch ($filterName) {
@@ -42,6 +50,16 @@ class EventUserFinder extends AbstractFinder
 
                     $qb->andWhere("u.uuid = :{$filterName}");
                     $qb->setParameter($filterName, $filterValue);
+                    break;
+
+                case 'userDisabled':
+                    if (!$userJoin) {
+                        $qb->join('obj.user', 'u');
+                        $userJoin = true;
+                    }
+                    $qb->andWhere('u.isEnabled = :isEnabled');
+                    $qb->andWhere('u.isRemoved = FALSE');
+                    $qb->setParameter('isEnabled', !$filterValue);
                     break;
 
                 case 'organizations':

--- a/src/plugin/cursus/Finder/Registration/SessionUserFinder.php
+++ b/src/plugin/cursus/Finder/Registration/SessionUserFinder.php
@@ -27,6 +27,15 @@ class SessionUserFinder extends AbstractFinder
         $userJoin = false;
         $sessionJoin = false;
 
+        if (!array_key_exists('userDisabled', $searches) && !array_key_exists('user', $searches)) {
+            // don't show registrations of disabled/deleted users
+            $qb->join('obj.user', 'u');
+            $userJoin = true;
+
+            $qb->andWhere('u.isEnabled = TRUE');
+            $qb->andWhere('u.isRemoved = FALSE');
+        }
+
         foreach ($searches as $filterName => $filterValue) {
             switch ($filterName) {
                 case 'course':
@@ -56,6 +65,16 @@ class SessionUserFinder extends AbstractFinder
 
                     $qb->andWhere("u.uuid = :{$filterName}");
                     $qb->setParameter($filterName, $filterValue);
+                    break;
+
+                case 'userDisabled':
+                    if (!$userJoin) {
+                        $qb->join('obj.user', 'u');
+                        $userJoin = true;
+                    }
+                    $qb->andWhere('u.isEnabled = :isEnabled');
+                    $qb->andWhere('u.isRemoved = FALSE');
+                    $qb->setParameter('isEnabled', !$filterValue);
                     break;
 
                 case 'organizations':

--- a/src/plugin/cursus/Resources/modules/event/components/participants.jsx
+++ b/src/plugin/cursus/Resources/modules/event/components/participants.jsx
@@ -139,6 +139,13 @@ const EventPresences = (props) =>
           </span>
         ),
         displayed: true
+      }, {
+        name: 'userDisabled',
+        label: trans('user_disabled'),
+        type: 'boolean',
+        displayable: false,
+        sortable: false,
+        filterable: true
       }
     ]}
     actions={(rows) => [

--- a/src/plugin/cursus/Resources/modules/session/components/users.jsx
+++ b/src/plugin/cursus/Resources/modules/session/components/users.jsx
@@ -35,6 +35,13 @@ const SessionUsers = (props) =>
           label: trans('registration_date', {}, 'cursus'),
           options: {time: true},
           displayed: true
+        }, {
+          name: 'userDisabled',
+          label: trans('user_disabled'),
+          type: 'boolean',
+          displayable: false,
+          sortable: false,
+          filterable: true
         }
       ]}
       actions={props.actions}

--- a/src/plugin/drop-zone/Resources/modules/resources/dropzone/correction/components/correctors.jsx
+++ b/src/plugin/drop-zone/Resources/modules/resources/dropzone/correction/components/correctors.jsx
@@ -88,6 +88,13 @@ const Correctors = props =>
             label: trans('unlocked', {}, 'dropzone'),
             displayed: true,
             type: 'boolean'
+          }, {
+            name: 'userDisabled',
+            label: trans('user_disabled'),
+            type: 'boolean',
+            displayable: false,
+            sortable: false,
+            filterable: true
           }
         ]}
         actions={(rows) => [

--- a/src/plugin/drop-zone/Resources/modules/resources/dropzone/correction/components/drops.jsx
+++ b/src/plugin/drop-zone/Resources/modules/resources/dropzone/correction/components/drops.jsx
@@ -96,6 +96,13 @@ const DropsList = props =>
             current: row.score,
             total: props.dropzone.parameters.scoreMax
           })
+        }, {
+          name: 'userDisabled',
+          label: trans('user_disabled'),
+          type: 'boolean',
+          displayable: false,
+          sortable: false,
+          filterable: true
         }
       ]}
       actions={(rows) => [

--- a/src/plugin/exo/Resources/modules/resources/quiz/papers/components/papers.jsx
+++ b/src/plugin/exo/Resources/modules/resources/quiz/papers/components/papers.jsx
@@ -101,6 +101,13 @@ const Papers = props =>
 
             return null
           }
+        }, {
+          name: 'userDisabled',
+          label: trans('user_disabled'),
+          type: 'boolean',
+          displayable: false,
+          sortable: false,
+          filterable: true
         }
       ]}
 

--- a/src/plugin/open-badge/Resources/modules/tools/badges/badge/components/details.jsx
+++ b/src/plugin/open-badge/Resources/modules/tools/badges/badge/components/details.jsx
@@ -106,6 +106,13 @@ const BadgeDetailsComponent = (props) => {
                 options: {
                   time: true
                 }
+              }, {
+                name: 'userDisabled',
+                label: trans('user_disabled'),
+                type: 'boolean',
+                displayable: false,
+                sortable: false,
+                filterable: true
               }
             ]}
             actions={(rows) => [

--- a/src/plugin/scorm/Finder/ScoTrackingFinder.php
+++ b/src/plugin/scorm/Finder/ScoTrackingFinder.php
@@ -26,11 +26,13 @@ class ScoTrackingFinder extends AbstractFinder
         $qb->join('obj.sco', 'sco');
 
         $userJoin = false;
-        if (!in_array('user', $searches) && !in_array('userEmail', $searches)) {
+        if (!array_key_exists('userDisabled', $searches) && !in_array('user', $searches) && !in_array('userEmail', $searches)) {
             // only return results for enabled users
             $qb->join('obj.user', 'u');
-            $qb->andWhere('u.isEnabled = true AND u.isRemoved = false');
             $userJoin = true;
+
+            $qb->andWhere('u.isEnabled = TRUE');
+            $qb->andWhere('u.isRemoved = FALSE');
         }
 
         foreach ($searches as $filterName => $filterValue) {
@@ -48,6 +50,16 @@ class ScoTrackingFinder extends AbstractFinder
                     }
                     $qb->andWhere("u.uuid = :{$filterName}");
                     $qb->setParameter($filterName, $filterValue);
+                    break;
+
+                case 'userDisabled':
+                    if (!$userJoin) {
+                        $qb->join('obj.user', 'u');
+                        $userJoin = true;
+                    }
+                    $qb->andWhere('u.isEnabled = :isEnabled');
+                    $qb->andWhere('u.isRemoved = FALSE');
+                    $qb->setParameter('isEnabled', !$filterValue);
                     break;
 
                 case 'userEmail':

--- a/src/plugin/scorm/Resources/modules/resources/scorm/player/components/results.jsx
+++ b/src/plugin/scorm/Resources/modules/resources/scorm/player/components/results.jsx
@@ -127,6 +127,13 @@ const ResultsComponent = props =>
           filterable: false,
           sortable: constants.SCORM_2004 === props.scorm.version,
           calculated: (rowData) => rowData.progression + '%'
+        }, {
+          name: 'userDisabled',
+          label: trans('user_disabled'),
+          type: 'boolean',
+          displayable: false,
+          sortable: false,
+          filterable: true
         }
       ]}
     />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no


The following lists have been updated : 
- Resource evaluations (also added to the data source)
- Workspace evaluations (also added to the data source)
- Scorm results
- Quiz results (also added default filter to active)
- Dropzone results (also added default filter to active)
- Workspace users
- Training/Session/Event/Presence users (also added default filter to active)
- Badge users (also added default filter to active)