### PR TITLE
Org selection updates main org, fixes #2017

### DIFF
--- a/src/main/core/Resources/modules/data/types/organization/components/choice.jsx
+++ b/src/main/core/Resources/modules/data/types/organization/components/choice.jsx
@@ -100,9 +100,27 @@ class OrganizationChoice extends Component {
       <FormFieldset
         id={this.props.id}
         data={this.state.selected}
-        updateProp={(name, value) => this.setState({
-          selected: [...this.state.selected.slice(0, parseInt(name)), value]
-        })}
+        updateProp={(name, value) => {
+          const getOrganization = (organizations, [currentId, ...restOfIds]) => {
+            if (isEmpty(currentId)) {
+              return []
+            }
+            
+            const currentOrganization = organizations.find(organization => organization.id === currentId)
+            
+            return currentOrganization && currentOrganization.children.length > 0 && restOfIds.length > 0
+              ? getOrganization(currentOrganization.children, restOfIds)
+              : currentOrganization
+          }
+          
+          const organization = getOrganization(this.state.organizations, [...this.state.selected.slice(0, parseInt(name)), value])
+
+          this.props.updateMainOrganization(organization.name, organization.code)
+
+          this.setState({
+            selected: [...this.state.selected.slice(0, parseInt(name)), value]
+          })
+        }}
         disabled={this.props.disabled}
         errors={this.props.error}
         fields={!isEmpty(this.state.organizations) ? this.getFields(this.state.organizations) : []}
@@ -129,7 +147,8 @@ OrganizationChoice.propTypes = {
   value: T.object,
   error: T.oneOfType([T.string, T.object]),
   onChange: T.func.isRequired,
-  onError: T.func.isRequired
+  onError: T.func.isRequired,
+  updateMainOrganization: T.func.isRequired
 }
 
 export {

--- a/src/main/core/Resources/modules/data/types/organization/components/choice.jsx
+++ b/src/main/core/Resources/modules/data/types/organization/components/choice.jsx
@@ -115,7 +115,7 @@ class OrganizationChoice extends Component {
           
           const organization = getOrganization(this.state.organizations, [...this.state.selected.slice(0, parseInt(name)), value])
 
-          this.props.updateMainOrganization({organizationName: organization.name, organizationCode: organization.code, formPath: this.props.id.startsWith('registration')})
+          this.props.updateMainOrganization({organizationId: organization.id, organizationName: organization.name, organizationCode: organization.code, isFormRegistration: this.props.id.startsWith('registration')})
 
           this.setState({
             selected: [...this.state.selected.slice(0, parseInt(name)), value]

--- a/src/main/core/Resources/modules/data/types/organization/components/choice.jsx
+++ b/src/main/core/Resources/modules/data/types/organization/components/choice.jsx
@@ -115,7 +115,7 @@ class OrganizationChoice extends Component {
           
           const organization = getOrganization(this.state.organizations, [...this.state.selected.slice(0, parseInt(name)), value])
 
-          this.props.updateMainOrganization(organization.name, organization.code)
+          this.props.updateMainOrganization({organizationName: organization.name, organizationCode: organization.code, formPath: this.props.id.startsWith('registration')})
 
           this.setState({
             selected: [...this.state.selected.slice(0, parseInt(name)), value]

--- a/src/main/core/Resources/modules/data/types/organization/components/input.jsx
+++ b/src/main/core/Resources/modules/data/types/organization/components/input.jsx
@@ -10,7 +10,7 @@ import {ContentPlaceholder} from '#/main/app/content/components/placeholder'
 import {OrganizationCard} from '#/main/core/user/data/components/organization-card'
 import {Organization as OrganizationTypes} from '#/main/core/user/prop-types'
 import {MODAL_ORGANIZATIONS} from '#/main/core/modals/organizations'
-import {OrganizationChoice} from '#/main/core/data/types/organization/components/choice'
+import {OrganizationChoice} from '#/main/core/data/types/organization/containers/choice'
 
 const OrganizationButton = props =>
   <Button

--- a/src/main/core/Resources/modules/data/types/organization/containers/choice.jsx
+++ b/src/main/core/Resources/modules/data/types/organization/containers/choice.jsx
@@ -1,0 +1,19 @@
+import {connect} from 'react-redux'
+
+import {actions as formActions} from '#/main/app/content/form/store'
+import {selectors} from '#/main/app/security/registration/store/selectors'
+import {OrganizationChoice} from '#/main/core/data/types/organization/components/choice'
+
+const ConnectedOrganizationChoice = connect(
+  null,
+  (dispatch) => (
+    {
+      updateMainOrganization(organizationName, organizationCode) {
+        dispatch(formActions.updateProp(selectors.FORM_NAME, 'mainOrganization.name', organizationName))
+        dispatch(formActions.updateProp(selectors.FORM_NAME, 'mainOrganization.code', organizationCode))
+      }
+    }
+  )
+)(OrganizationChoice)
+
+export {ConnectedOrganizationChoice as OrganizationChoice}

--- a/src/main/core/Resources/modules/data/types/organization/containers/choice.jsx
+++ b/src/main/core/Resources/modules/data/types/organization/containers/choice.jsx
@@ -1,14 +1,17 @@
 import {connect} from 'react-redux'
 
 import {actions as formActions} from '#/main/app/content/form/store'
-import {selectors} from '#/main/app/security/registration/store/selectors'
+import {selectors as registrationSelectors} from '#/main/app/security/registration/store/selectors'
+import {selectors as profileSelectors} from '#/main/core/user/profile/store/selectors'
 import {OrganizationChoice} from '#/main/core/data/types/organization/components/choice'
 
 const ConnectedOrganizationChoice = connect(
   null,
   (dispatch) => (
     {
-      updateMainOrganization(organizationName, organizationCode) {
+      updateMainOrganization({organizationName, organizationCode, formPath}) {
+        const selectors = formPath ? registrationSelectors : profileSelectors
+        
         dispatch(formActions.updateProp(selectors.FORM_NAME, 'mainOrganization.name', organizationName))
         dispatch(formActions.updateProp(selectors.FORM_NAME, 'mainOrganization.code', organizationCode))
       }

--- a/src/main/core/Resources/modules/data/types/organization/containers/choice.jsx
+++ b/src/main/core/Resources/modules/data/types/organization/containers/choice.jsx
@@ -9,9 +9,10 @@ const ConnectedOrganizationChoice = connect(
   null,
   (dispatch) => (
     {
-      updateMainOrganization({organizationName, organizationCode, formPath}) {
-        const selectors = formPath ? registrationSelectors : profileSelectors
+      updateMainOrganization({organizationId, organizationName, organizationCode, isFormRegistration}) {
+        const selectors = isFormRegistration ? registrationSelectors : profileSelectors
         
+        dispatch(formActions.updateProp(selectors.FORM_NAME, 'mainOrganization.id', organizationId))
         dispatch(formActions.updateProp(selectors.FORM_NAME, 'mainOrganization.name', organizationName))
         dispatch(formActions.updateProp(selectors.FORM_NAME, 'mainOrganization.code', organizationCode))
       }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed issues | #2017

As discussed here:
https://github.com/claroline/Claroline/issues/2017#issuecomment-1025775574

This is deployed in our Val and Prod environments, it works for us and for our client, it solves most issues without introducing and new ones, the client confirmed that they'll never have more than 1 field of this type in their form (and even if someone does, it only makes sense if it's behind a condition, so they'll still never be visible at the same time), and it's OK for administrators to impersonate users in order to modify their profile's organization selection field

Please consider reviewing and merging it, or let us know how we can improve, so that we can avoid maintaining this branch in our fork for years
