### PR TITLE
fix adding a created user to their organization when login with saml

### DIFF
--- a/src/plugin/saml/Controller/AuthenticationController.php
+++ b/src/plugin/saml/Controller/AuthenticationController.php
@@ -29,10 +29,6 @@ class AuthenticationController extends AbstractController
             return $this->redirect($this->generateUrl($this->container->getParameter('lightsaml_sp.route.discovery')));
         }
 
-        // we store idp in session to retrieve it at the end of authentication success
-        // in order to register user to correct groups and organization based on the idp configuration
-        $request->getSession()->set('authIdp', $idpEntityId);
-
         $profile = $this->get('ligthsaml.profile.login_factory')->get($idpEntityId);
         $context = $profile->buildContext();
         $action = $profile->buildAction();

--- a/src/plugin/saml/Security/Authentication/AuthenticationSuccessListener.php
+++ b/src/plugin/saml/Security/Authentication/AuthenticationSuccessListener.php
@@ -52,7 +52,12 @@ class AuthenticationSuccessListener extends BaseAuthenticationSuccessListener
         $user = $token->getUser();
 
         // apply IDP config
-        $idpEntityId = $request->getSession()->get('authIdp');
+        $sessions = $request->getSession()->get('samlsso')->getSsoSessions();
+        if (empty($sessions)) {
+            return null;
+        }
+        $session = $sessions[count($sessions) - 1];
+        $idpEntityId = $session->getIdpEntityId();
 
         // register user to the Organizations and Groups defined on the IDP
         if ($idpEntityId) {

--- a/src/plugin/saml/Security/Authentication/AuthenticationSuccessListener.php
+++ b/src/plugin/saml/Security/Authentication/AuthenticationSuccessListener.php
@@ -54,7 +54,7 @@ class AuthenticationSuccessListener extends BaseAuthenticationSuccessListener
         // apply IDP config
         $sessions = $request->getSession()->get('samlsso')->getSsoSessions();
         if (empty($sessions)) {
-            return null;
+            return parent::onAuthenticationSuccess($request, $token);
         }
         $session = $sessions[count($sessions) - 1];
         $idpEntityId = $session->getIdpEntityId();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed issues | 

Fix adding a created user to their corresponding organization and group when login with saml as per SAML config in platform_options.json


