### PR TITLE
[SAML] Login with IAM - new behavior for organization assignment

### DIFF
--- a/src/plugin/saml/Security/Authentication/AuthenticationSuccessListener.php
+++ b/src/plugin/saml/Security/Authentication/AuthenticationSuccessListener.php
@@ -61,7 +61,7 @@ class AuthenticationSuccessListener extends BaseAuthenticationSuccessListener
 
             // attach user to the defined organization
             $organization = $this->idpManager->getOrganization($idpEntityId, $user->getEmail(), $attributes);
-            if ($organization && (empty($user->getMainOrganization()) || $organization->getId() !== $user->getMainOrganization()->getId())) {
+            if ($organization && (empty($user->getMainOrganization()) || $user->getMainOrganization()->isDefault())) {
                 // reset organization if it has changed or has not been set (eg. user has just been created)
                 $this->crud->replace($user, 'mainOrganization', $organization, [Crud::THROW_EXCEPTION, Crud::NO_PERMISSIONS, Options::NO_EMAIL]);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Fixed issues | 

SAML login should only force organization if new account or if current organization is default

This is the required behavior for our client and is deployed to our Val and Prod envs, let us know if it seems useful to be merged
