### PR TITLE
[Profile] Force fill required visible fields in own profile edit, fixes #2021

### DIFF
--- a/src/main/app/Resources/config/services.yml
+++ b/src/main/app/Resources/config/services.yml
@@ -26,6 +26,7 @@ services:
             - '@Claroline\AppBundle\API\SerializerProvider'
             - '@Claroline\AppBundle\API\ValidatorProvider'
             - '@Claroline\AppBundle\API\SchemaProvider'
+            - '@Claroline\CoreBundle\Manager\FacetManager'
             - '@security.authorization_checker'
 
     Claroline\AppBundle\API\SchemaProvider:

--- a/src/main/core/Controller/APINew/User/ProfileController.php
+++ b/src/main/core/Controller/APINew/User/ProfileController.php
@@ -125,7 +125,7 @@ class ProfileController
         // those roles should not be here anyway.
         unset($userData['roles']);
 
-        $updated = $this->crud->update($user, $userData, [Crud::THROW_EXCEPTION, Options::SERIALIZE_FACET]);
+        $updated = $this->crud->update($user, $userData, [Crud::THROW_EXCEPTION, Options::SERIALIZE_FACET, Options::VALIDATE_FACET], $this->profileSerializer);
 
         return new JsonResponse(
             $this->serializer->serialize($updated, [Options::SERIALIZE_FACET])
@@ -150,7 +150,7 @@ class ProfileController
         // updates facets data
         $updatedFacets = [];
         foreach ($formData as $facetData) {
-            $updated = $this->crud->update(Facet::class, $facetData, [Options::DEEP_DESERIALIZE]);
+            $updated = $this->crud->update(Facet::class, $facetData, [Options::DEEP_DESERIALIZE], null);
             $updatedFacets[$updated->getId()] = $updated;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed issues | #2021

[Profile] Force fill required visible fields in own profile edit, fixes #2021

Technical notes:
I tried importing the $profileSerializer just like in UserValidator.php, but it threw some errors related to circular dependencies and out-of-memory, so I had to pass it to the function - it seems wrong, but I don't know how to refactor it in order to make the imports work
I also wasn't sure how to directly reuse the validation code instead of duplicating it from UserValidator.php