### PR TITLE
Fix messenger configuration

### DIFF
--- a/src/main/app/ClarolineAppBundle.php
+++ b/src/main/app/ClarolineAppBundle.php
@@ -74,6 +74,7 @@ class ClarolineAppBundle extends Bundle implements AutoConfigurableInterface
             'security' => true,
             'monolog' => true,
             'doctrine' => true,
+            'messenger' => true,
         ];
 
         foreach ($configs as $configKey => $envConfig) {

--- a/src/main/app/Resources/config/suggested/doctrine_prod.yml
+++ b/src/main/app/Resources/config/suggested/doctrine_prod.yml
@@ -10,7 +10,6 @@ doctrine:
         charset:        UTF8
         options:
             1002: 'SET sql_mode=(SELECT REPLACE(@@sql_mode, "ONLY_FULL_GROUP_BY", ""))'
-        schema_filter: '~^(?!messenger_messages)~'
 
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"

--- a/src/main/app/Resources/config/suggested/doctrine_test.yml
+++ b/src/main/app/Resources/config/suggested/doctrine_test.yml
@@ -8,4 +8,3 @@ doctrine:
         dbname:   '%test_database_name%'
         user:     '%test_database_user%'
         password: '%test_database_password%'
-        schema_filter: '~^(?!messenger_messages)~'

--- a/src/main/app/Resources/config/suggested/messenger_prod.yml
+++ b/src/main/app/Resources/config/suggested/messenger_prod.yml
@@ -2,8 +2,8 @@ framework:
     messenger:
         failure_transport: failed
         transports:
-            async:
-                dsn: '%messenger.dsn%'
+            default:
+                dsn: 'doctrine://default' # overridden in MessengerConfigPass
 
                 # default configuration
                 retry_strategy:
@@ -21,4 +21,4 @@ framework:
             failed: 'doctrine://default?queue_name=failed'
 
         routing:
-            'Claroline\AppBundle\Message\AsyncInterface': async
+            'Claroline\AppBundle\Messenger\Message\AsyncMessageInterface': default

--- a/src/main/core/DependencyInjection/Compiler/MessengerConfigPass.php
+++ b/src/main/core/DependencyInjection/Compiler/MessengerConfigPass.php
@@ -15,17 +15,21 @@ use Claroline\CoreBundle\Library\Configuration\PlatformConfigurationHandler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+// Configures messenger to be async or sync depending on the "job_queue.enabled" platform option
 class MessengerConfigPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
+        if (!$container->hasDefinition('messenger.transport.default')) {
+            throw new \LogicException('Unable to configure messenger, make sure it is correctly configured.');
+        }
+
         /** @var PlatformConfigurationHandler $platformConfig */
         $platformConfig = $container->get(PlatformConfigurationHandler::class);
+        $transportDefinition = $container->getDefinition('messenger.transport.default');
 
-        if ($platformConfig->getParameter('job_queue.enabled')) {
-            $container->setParameter('messenger.dsn', 'doctrine://default');
-        } else {
-            $container->setParameter('messenger.dsn', 'sync://');
+        if (!$platformConfig->getParameter('job_queue.enabled')) {
+            $transportDefinition->replaceArgument(0, 'sync://');
         }
     }
 }

--- a/src/main/core/DependencyInjection/Compiler/MessengerConfigPass.php
+++ b/src/main/core/DependencyInjection/Compiler/MessengerConfigPass.php
@@ -15,7 +15,9 @@ use Claroline\CoreBundle\Library\Configuration\PlatformConfigurationHandler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-// Configures messenger to be async or sync depending on the "job_queue.enabled" platform option
+/**
+ * Configures messenger to be async or sync depending on the "job_queue.enabled" platform option.
+ */
 class MessengerConfigPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)

--- a/src/main/core/Installation/Migrations/pdo_mysql/Version20220316181246.php
+++ b/src/main/core/Installation/Migrations/pdo_mysql/Version20220316181246.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Claroline\CoreBundle\Installation\Migrations\pdo_mysql;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated migration based on mapping information: modify it with caution.
+ *
+ * Generation date: 2022/03/16 06:12:50
+ */
+class Version20220316181246 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('
+            CREATE TABLE messenger_messages (
+                id INT AUTO_INCREMENT NOT NULL, 
+                body LONGTEXT NOT NULL, 
+                headers LONGTEXT NOT NULL, 
+                queue_name VARCHAR(36) NOT NULL, 
+                created_at DATETIME NOT NULL, 
+                available_at DATETIME NOT NULL, 
+                delivered_at DATETIME DEFAULT NULL,
+                INDEX IDX_75EA56E016BA31DB (delivered_at), 
+                PRIMARY KEY(id)
+            ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB
+        ');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('
+            DROP TABLE messenger_messages
+        ');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed issues | -

The suggested configuration for messenger was not loaded.
Additionally, using a parameter to change the dsn of our transport does not work because of how messenger is configured in the framework so we need to modify the transport service definition directly.
Since the transport can be made sync as well as async, I renamed it from `async` to `default`.


