### PR TITLE
fixes js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "swagger-ui-react": "3.51.2",
     "tinycolor2": "^1.4.1",
     "tinymce": "^4.9.3",
-    "tinymce-codemirror": "git://github.com/christiaan/tinymce-codemirror.git#20c1bbe708",
+    "tinymce-codemirror": "git+https://github.com/christiaan/tinymce-codemirror.git#20c1bbe708",
     "uuid": "^3.3.2",
     "video.js": "7.7.4",
     "wavesurfer.js": "2.2.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

Try to fix ` The unauthenticated git protocol on port 9418 is no longer supported.` error.