### PR TITLE
[Messenger] fixes async messages

### DIFF
--- a/src/main/core/Messenger/Message/DisableInactiveUsers.php
+++ b/src/main/core/Messenger/Message/DisableInactiveUsers.php
@@ -11,10 +11,12 @@
 
 namespace Claroline\CoreBundle\Messenger\Message;
 
+use Claroline\AppBundle\Messenger\Message\AsyncMessageInterface;
+
 /**
  * Disable all users which have not logged in since the selected date.
  */
-class DisableInactiveUsers
+class DisableInactiveUsers implements AsyncMessageInterface
 {
     /** @var \DateTimeInterface */
     private $lastActivity;

--- a/src/main/core/Messenger/Message/SendMessage.php
+++ b/src/main/core/Messenger/Message/SendMessage.php
@@ -11,25 +11,25 @@
 
 namespace Claroline\CoreBundle\Messenger\Message;
 
-use Claroline\CoreBundle\Entity\User;
+use Claroline\AppBundle\Messenger\Message\AsyncMessageInterface;
 
-class SendMessage
+class SendMessage implements AsyncMessageInterface
 {
     /** @var string */
     private $content;
     /** @var string */
     private $object;
     /** @var array */
-    private $receivers;
-    /** @var User|null */
-    private $sender;
+    private $receiverIds;
+    /** @var int|null */
+    private $senderId;
 
-    public function __construct(string $content, string $object, array $receivers, ?User $sender = null)
+    public function __construct(string $content, string $object, array $receiverIds, ?int $senderId = null)
     {
         $this->content = $content;
         $this->object = $object;
-        $this->receivers = $receivers;
-        $this->sender = $sender;
+        $this->receiverIds = $receiverIds;
+        $this->senderId = $senderId;
     }
 
     public function getContent(): string
@@ -42,13 +42,13 @@ class SendMessage
         return $this->object;
     }
 
-    public function getReceivers(): array
+    public function getReceiverIds(): array
     {
-        return $this->receivers;
+        return $this->receiverIds;
     }
 
-    public function getSender(): ?User
+    public function getSenderId(): ?int
     {
-        return $this->sender;
+        return $this->senderId;
     }
 }

--- a/src/main/core/Messenger/SendMessageHandler.php
+++ b/src/main/core/Messenger/SendMessageHandler.php
@@ -12,6 +12,8 @@
 namespace Claroline\CoreBundle\Messenger;
 
 use Claroline\AppBundle\Event\StrictDispatcher;
+use Claroline\AppBundle\Persistence\ObjectManager;
+use Claroline\CoreBundle\Entity\User;
 use Claroline\CoreBundle\Event\CatalogEvents\MessageEvents;
 use Claroline\CoreBundle\Event\SendMessageEvent;
 use Claroline\CoreBundle\Messenger\Message\SendMessage;
@@ -21,18 +23,37 @@ class SendMessageHandler implements MessageHandlerInterface
 {
     /** @var StrictDispatcher */
     private $dispatcher;
+    /** @var ObjectManager */
+    private $om;
 
-    public function __construct(StrictDispatcher $dispatcher)
-    {
+    public function __construct(
+        StrictDispatcher $dispatcher,
+        ObjectManager $om
+    ) {
         $this->dispatcher = $dispatcher;
+        $this->om = $om;
     }
 
     public function __invoke(SendMessage $message)
     {
+        $receivers = [];
+        foreach ($message->getReceiverIds() as $receiverId) {
+            $receiver = $this->om->getRepository(User::class)->find($receiverId);
+            if (!empty($receiver)) {
+                $receivers[] = $receiver;
+            }
+        }
+
+        $sender = null;
+        if ($message->getSenderId()) {
+            $sender = $this->om->getRepository(User::class)->find($message->getSenderId());
+        }
+
         $this->dispatcher->dispatch(MessageEvents::MESSAGE_SENDING, SendMessageEvent::class, [
             $message->getContent(),
             $message->getObject(),
-            $message->getReceivers(),
+            $receivers,
+            $sender,
         ]);
     }
 }

--- a/src/main/core/Resources/config/services/messenger.yml
+++ b/src/main/core/Resources/config/services/messenger.yml
@@ -9,3 +9,4 @@ services:
         tags: [messenger.message_handler]
         arguments:
             - '@Claroline\AppBundle\Event\StrictDispatcher'
+            - '@Claroline\AppBundle\Persistence\ObjectManager'

--- a/src/main/evaluation/Controller/WorkspaceEvaluationController.php
+++ b/src/main/evaluation/Controller/WorkspaceEvaluationController.php
@@ -184,7 +184,11 @@ class WorkspaceEvaluationController extends AbstractSecurityController
 
         $users = $this->om->getRepository(User::class)->findByWorkspaces([$workspace]);
         if (!empty($users)) {
-            $this->messageBus->dispatch(new InitializeWorkspaceEvaluations($workspace, $users));
+            $this->messageBus->dispatch(
+                new InitializeWorkspaceEvaluations($workspace->getId(), array_map(function (User $user) {
+                    return $user->getId();
+                }, $users))
+            );
         }
 
         return new JsonResponse(null, 204);

--- a/src/main/evaluation/Messenger/InitializeResourceEvaluationsHandler.php
+++ b/src/main/evaluation/Messenger/InitializeResourceEvaluationsHandler.php
@@ -3,7 +3,9 @@
 namespace Claroline\EvaluationBundle\Messenger;
 
 use Claroline\AppBundle\Persistence\ObjectManager;
+use Claroline\CoreBundle\Entity\Resource\ResourceNode;
 use Claroline\CoreBundle\Entity\Resource\ResourceUserEvaluation;
+use Claroline\CoreBundle\Entity\User;
 use Claroline\EvaluationBundle\Entity\AbstractEvaluation;
 use Claroline\EvaluationBundle\Messenger\Message\InitializeResourceEvaluations;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
@@ -21,8 +23,19 @@ class InitializeResourceEvaluationsHandler implements MessageHandlerInterface
 
     public function __invoke(InitializeResourceEvaluations $initMessage)
     {
-        $resourceNode = $initMessage->getResourceNode();
-        $users = $initMessage->getUsers();
+        $resourceNode = $this->om->getRepository(ResourceNode::class)->find($initMessage->getResourceNodeId());
+        if (empty($resourceNode)) {
+            return;
+        }
+
+        $users = [];
+        foreach ($initMessage->getUserIds() as $userId) {
+            $user = $this->om->getRepository(User::class)->find($userId);
+            if (!empty($user)) {
+                $users[] = $user;
+            }
+        }
+
         $status = $initMessage->getStatus();
 
         $this->om->startFlushSuite();

--- a/src/main/evaluation/Messenger/Message/InitializeResourceEvaluations.php
+++ b/src/main/evaluation/Messenger/Message/InitializeResourceEvaluations.php
@@ -2,34 +2,33 @@
 
 namespace Claroline\EvaluationBundle\Messenger\Message;
 
-use Claroline\CoreBundle\Entity\Resource\ResourceNode;
-use Claroline\CoreBundle\Entity\User;
+use Claroline\AppBundle\Messenger\Message\AsyncMessageInterface;
 use Claroline\EvaluationBundle\Entity\AbstractEvaluation;
 
-class InitializeResourceEvaluations
+class InitializeResourceEvaluations implements AsyncMessageInterface
 {
-    /** @var ResourceNode */
-    private $resourceNode;
-    /** @var User[] */
-    private $users;
+    /** @var int */
+    private $resourceNodeId;
+    /** @var int[] */
+    private $userIds;
     /** @var string */
     private $status;
 
-    public function __construct(ResourceNode $resourceNode, array $users, string $status = AbstractEvaluation::STATUS_NOT_ATTEMPTED)
+    public function __construct(int $resourceNodeId, array $userIds, string $status = AbstractEvaluation::STATUS_NOT_ATTEMPTED)
     {
-        $this->resourceNode = $resourceNode;
-        $this->users = $users;
+        $this->resourceNodeId = $resourceNodeId;
+        $this->userIds = $userIds;
         $this->status = $status;
     }
 
-    public function getResourceNode(): ResourceNode
+    public function getResourceNodeId(): int
     {
-        return $this->resourceNode;
+        return $this->resourceNodeId;
     }
 
-    public function getUsers(): array
+    public function getUserIds(): array
     {
-        return $this->users;
+        return $this->userIds;
     }
 
     public function getStatus(): string

--- a/src/main/evaluation/Messenger/Message/InitializeWorkspaceEvaluations.php
+++ b/src/main/evaluation/Messenger/Message/InitializeWorkspaceEvaluations.php
@@ -2,29 +2,28 @@
 
 namespace Claroline\EvaluationBundle\Messenger\Message;
 
-use Claroline\CoreBundle\Entity\User;
-use Claroline\CoreBundle\Entity\Workspace\Workspace;
+use Claroline\AppBundle\Messenger\Message\AsyncMessageInterface;
 
-class InitializeWorkspaceEvaluations
+class InitializeWorkspaceEvaluations implements AsyncMessageInterface
 {
-    /** @var Workspace */
-    private $workspace;
-    /** @var User[] */
-    private $users;
+    /** @var int */
+    private $workspaceId;
+    /** @var int[] */
+    private $userIds;
 
-    public function __construct(Workspace $workspace, array $users)
+    public function __construct(int $workspaceId, array $userIds)
     {
-        $this->workspace = $workspace;
-        $this->users = $users;
+        $this->workspaceId = $workspaceId;
+        $this->userIds = $userIds;
     }
 
-    public function getWorkspace(): Workspace
+    public function getWorkspaceId(): int
     {
-        return $this->workspace;
+        return $this->workspaceId;
     }
 
-    public function getUsers(): array
+    public function getUserIds(): array
     {
-        return $this->users;
+        return $this->userIds;
     }
 }

--- a/src/main/evaluation/Subscriber/ResourceEvaluationSubscriber.php
+++ b/src/main/evaluation/Subscriber/ResourceEvaluationSubscriber.php
@@ -54,11 +54,19 @@ class ResourceEvaluationSubscriber implements EventSubscriberInterface
         if ((empty($oldData['evaluation']) || $resourceNode->isRequired() !== $oldData['evaluation']['required'])) {
             $registeredUsers = $this->userRepo->findByWorkspaces([$resourceNode->getWorkspace()]);
             if (!empty($registeredUsers)) {
+                $registeredUserIds = array_map(function (User $user) {
+                    return $user->getId();
+                }, $registeredUsers);
+
                 if ($resourceNode->isRequired()) {
-                    $this->messageBus->dispatch(new InitializeResourceEvaluations($resourceNode, $registeredUsers, AbstractEvaluation::STATUS_TODO));
+                    $this->messageBus->dispatch(
+                        new InitializeResourceEvaluations($resourceNode->getId(), $registeredUserIds, AbstractEvaluation::STATUS_TODO)
+                    );
                 } else {
                     // TODO : do an update, as is it will generate missing evaluations and we don't want to
-                    $this->messageBus->dispatch(new InitializeResourceEvaluations($resourceNode, $registeredUsers, AbstractEvaluation::STATUS_NOT_ATTEMPTED));
+                    $this->messageBus->dispatch(
+                        new InitializeResourceEvaluations($resourceNode->getId(), $registeredUserIds, AbstractEvaluation::STATUS_NOT_ATTEMPTED)
+                    );
                 }
             }
         }

--- a/src/main/evaluation/Subscriber/WorkspaceEvaluationSubscriber.php
+++ b/src/main/evaluation/Subscriber/WorkspaceEvaluationSubscriber.php
@@ -88,7 +88,11 @@ class WorkspaceEvaluationSubscriber implements EventSubscriberInterface
         // event if they have not opened the workspace yet.
         $workspaces = $this->workspaceRepo->findByRoles([$role->getName()]);
         foreach ($workspaces as $workspace) {
-            $this->messageBus->dispatch(new InitializeWorkspaceEvaluations($workspace, $event->getUsers()));
+            $this->messageBus->dispatch(
+                new InitializeWorkspaceEvaluations($workspace->getId(), array_map(function (User $user) {
+                    return $user->getId();
+                }, $event->getUsers()))
+            );
         }
     }
 

--- a/src/main/log/Messenger/CreateFunctionalLogHandler.php
+++ b/src/main/log/Messenger/CreateFunctionalLogHandler.php
@@ -3,6 +3,9 @@
 namespace Claroline\LogBundle\Messenger;
 
 use Claroline\AppBundle\Persistence\ObjectManager;
+use Claroline\CoreBundle\Entity\Resource\ResourceNode;
+use Claroline\CoreBundle\Entity\User;
+use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Claroline\LogBundle\Entity\FunctionalLog;
 use Claroline\LogBundle\Messenger\Message\CreateFunctionalLog;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
@@ -19,14 +22,28 @@ class CreateFunctionalLogHandler implements MessageHandlerInterface
 
     public function __invoke(CreateFunctionalLog $createLog)
     {
+        $doer = $this->om->getRepository(User::class)->find($createLog->getDoerId());
+        if (empty($doer)) {
+            // missing data, no need to log things
+            return;
+        }
+
         $logEntry = new FunctionalLog();
 
         $logEntry->setDate($createLog->getDate());
         $logEntry->setEvent($createLog->getAction());
         $logEntry->setDetails($createLog->getDetails());
-        $logEntry->setUser($createLog->getDoer());
-        $logEntry->setWorkspace($createLog->getWorkspace());
-        $logEntry->setResource($createLog->getResourceNode());
+        $logEntry->setUser($doer);
+
+        if ($createLog->getWorkspaceId()) {
+            $workspace = $this->om->getRepository(Workspace::class)->find($createLog->getWorkspaceId());
+            $logEntry->setWorkspace($workspace);
+        }
+
+        if ($createLog->getResourceNodeId()) {
+            $resourceNode = $this->om->getRepository(ResourceNode::class)->find($createLog->getResourceNodeId());
+            $logEntry->setResource($resourceNode);
+        }
 
         $this->om->persist($logEntry);
         $this->om->flush();

--- a/src/main/log/Messenger/CreateSecurityLogHandler.php
+++ b/src/main/log/Messenger/CreateSecurityLogHandler.php
@@ -3,6 +3,7 @@
 namespace Claroline\LogBundle\Messenger;
 
 use Claroline\AppBundle\Persistence\ObjectManager;
+use Claroline\CoreBundle\Entity\User;
 use Claroline\CoreBundle\Library\GeoIp\GeoIpInfoProviderInterface;
 use Claroline\LogBundle\Entity\SecurityLog;
 use Claroline\LogBundle\Messenger\Message\CreateSecurityLog;
@@ -30,8 +31,17 @@ class CreateSecurityLogHandler implements MessageHandlerInterface
         $logEntry->setDate($createLog->getDate());
         $logEntry->setEvent($createLog->getAction());
         $logEntry->setDetails($createLog->getDetails());
-        $logEntry->setDoer($createLog->getDoer());
-        $logEntry->setTarget($createLog->getTarget());
+
+        if ($createLog->getDoerId()) {
+            $doer = $this->om->getRepository(User::class)->find($createLog->getDoerId());
+            $logEntry->setDoer($doer);
+        }
+
+        if ($createLog->getTargetId()) {
+            $target = $this->om->getRepository(User::class)->find($createLog->getTargetId());
+            $logEntry->setTarget($target);
+        }
+
         $logEntry->setDoerIp($createLog->getDoerIp());
 
         $doerLocation = $this->getDoerLocation($createLog->getDoerIp());

--- a/src/main/log/Messenger/Message/CreateFunctionalLog.php
+++ b/src/main/log/Messenger/Message/CreateFunctionalLog.php
@@ -3,9 +3,6 @@
 namespace Claroline\LogBundle\Messenger\Message;
 
 use Claroline\AppBundle\Messenger\Message\AsyncMessageInterface;
-use Claroline\CoreBundle\Entity\Resource\ResourceNode;
-use Claroline\CoreBundle\Entity\User;
-use Claroline\CoreBundle\Entity\Workspace\Workspace;
 
 class CreateFunctionalLog implements AsyncMessageInterface
 {
@@ -15,27 +12,27 @@ class CreateFunctionalLog implements AsyncMessageInterface
     private $action;
     /** @var string */
     private $details;
-    /** @var User */
-    private $doer;
-    /** @var Workspace|null */
-    private $workspace;
-    /** @var ResourceNode|null */
-    private $resourceNode;
+    /** @var int */
+    private $doerId;
+    /** @var int */
+    private $workspaceId;
+    /** @var int */
+    private $resourceNodeId;
 
     public function __construct(
         \DateTimeInterface $date,
         string $action,
         string $details,
-        User $doer,
-        ?Workspace $workspace = null,
-        ?ResourceNode $resourceNode = null
+        int $doerId,
+        ?int $workspaceId = null,
+        ?int $resourceNodeId = null
     ) {
         $this->date = $date;
         $this->action = $action;
         $this->details = $details;
-        $this->doer = $doer;
-        $this->workspace = $workspace;
-        $this->resourceNode = $resourceNode;
+        $this->doerId = $doerId;
+        $this->workspaceId = $workspaceId;
+        $this->resourceNodeId = $resourceNodeId;
     }
 
     public function getDate(): \DateTimeInterface
@@ -53,18 +50,18 @@ class CreateFunctionalLog implements AsyncMessageInterface
         return $this->details;
     }
 
-    public function getDoer(): User
+    public function getDoerId(): int
     {
-        return $this->doer;
+        return $this->doerId;
     }
 
-    public function getWorkspace(): ?Workspace
+    public function getWorkspaceId(): ?int
     {
-        return $this->workspace;
+        return $this->workspaceId;
     }
 
-    public function getResourceNode(): ?ResourceNode
+    public function getResourceNodeId(): ?int
     {
-        return $this->resourceNode;
+        return $this->resourceNodeId;
     }
 }

--- a/src/main/log/Messenger/Message/CreateRoleChangeLogs.php
+++ b/src/main/log/Messenger/Message/CreateRoleChangeLogs.php
@@ -3,8 +3,6 @@
 namespace Claroline\LogBundle\Messenger\Message;
 
 use Claroline\AppBundle\Messenger\Message\AsyncMessageInterface;
-use Claroline\CoreBundle\Entity\Role;
-use Claroline\CoreBundle\Entity\User;
 
 class CreateRoleChangeLogs implements AsyncMessageInterface
 {
@@ -12,29 +10,29 @@ class CreateRoleChangeLogs implements AsyncMessageInterface
     private $date;
     /** @var string */
     private $action;
-    /** @var Role */
-    private $role;
+    /** @var int */
+    private $roleId;
     /** @var string */
     private $doerIp;
-    /** @var User */
-    private $doer;
+    /** @var int */
+    private $doerId;
     /** @var array */
-    private $targets;
+    private $targetIds;
 
     public function __construct(
         \DateTimeInterface $date,
         string $action,
-        Role $role,
+        int $roleId,
         string $doerIp,
-        ?User $doer = null,
-        array $targets = []
+        ?int $doerId = null,
+        array $targetIds = []
     ) {
         $this->date = $date;
         $this->action = $action;
-        $this->role = $role;
+        $this->roleId = $roleId;
         $this->doerIp = $doerIp;
-        $this->doer = $doer;
-        $this->targets = $targets;
+        $this->doerId = $doerId;
+        $this->targetIds = $targetIds;
     }
 
     public function getDate(): \DateTimeInterface
@@ -47,9 +45,9 @@ class CreateRoleChangeLogs implements AsyncMessageInterface
         return $this->action;
     }
 
-    public function getRole(): Role
+    public function getRoleId(): int
     {
-        return $this->role;
+        return $this->roleId;
     }
 
     public function getDoerIp(): string
@@ -57,13 +55,13 @@ class CreateRoleChangeLogs implements AsyncMessageInterface
         return $this->doerIp;
     }
 
-    public function getDoer(): ?User
+    public function getDoerId(): ?int
     {
-        return $this->doer;
+        return $this->doerId;
     }
 
-    public function getTargets(): array
+    public function getTargetIds(): array
     {
-        return $this->targets;
+        return $this->targetIds;
     }
 }

--- a/src/main/log/Messenger/Message/CreateSecurityLog.php
+++ b/src/main/log/Messenger/Message/CreateSecurityLog.php
@@ -3,7 +3,6 @@
 namespace Claroline\LogBundle\Messenger\Message;
 
 use Claroline\AppBundle\Messenger\Message\AsyncMessageInterface;
-use Claroline\CoreBundle\Entity\User;
 
 class CreateSecurityLog implements AsyncMessageInterface
 {
@@ -15,25 +14,25 @@ class CreateSecurityLog implements AsyncMessageInterface
     private $details;
     /** @var string */
     private $doerIp;
-    /** @var User */
-    private $doer;
-    /** @var User */
-    private $target;
+    /** @var int */
+    private $doerId;
+    /** @var int */
+    private $targetId;
 
     public function __construct(
         \DateTimeInterface $date,
         string $action,
         string $details,
         string $doerIp,
-        ?User $doer = null,
-        ?User $target = null
+        ?int $doerId = null,
+        ?int $targetId = null
     ) {
         $this->date = $date;
         $this->action = $action;
         $this->details = $details;
         $this->doerIp = $doerIp;
-        $this->doer = $doer;
-        $this->target = $target;
+        $this->doerId = $doerId;
+        $this->targetId = $targetId;
     }
 
     public function getDate(): \DateTimeInterface
@@ -56,13 +55,13 @@ class CreateSecurityLog implements AsyncMessageInterface
         return $this->doerIp;
     }
 
-    public function getDoer(): ?User
+    public function getDoerId(): ?int
     {
-        return $this->doer;
+        return $this->doerId;
     }
 
-    public function getTarget(): ?User
+    public function getTargetId(): ?int
     {
-        return $this->target;
+        return $this->targetId;
     }
 }

--- a/src/main/log/Subscriber/Functional/GroupLogSubscriber.php
+++ b/src/main/log/Subscriber/Functional/GroupLogSubscriber.php
@@ -67,7 +67,7 @@ class GroupLogSubscriber implements EventSubscriberInterface
                     '%group%' => $group,
                     '%user%' => $user,
                 ], 'log'),
-                $this->security->getUser()
+                $this->security->getUser()->getId()
             ));
         } elseif (Crud::COLLECTION_REMOVE === $action) {
             $this->messageBus->dispatch(new CreateFunctionalLog(
@@ -77,7 +77,7 @@ class GroupLogSubscriber implements EventSubscriberInterface
                     '%group%' => $group,
                     '%user%' => $user,
                 ], 'log'),
-                $this->security->getUser()
+                $this->security->getUser()->getId()
             ));
         }
     }

--- a/src/main/log/Subscriber/Functional/OrganizationLogSubscriber.php
+++ b/src/main/log/Subscriber/Functional/OrganizationLogSubscriber.php
@@ -67,7 +67,7 @@ class OrganizationLogSubscriber implements EventSubscriberInterface
                     '%organization%' => $organization->getName(),
                     '%user%' => $user,
                 ], 'log'),
-                $this->security->getUser()
+                $this->security->getUser()->getId()
             ));
         } elseif (Crud::COLLECTION_REMOVE === $action) {
             $this->messageBus->dispatch(new CreateFunctionalLog(
@@ -77,7 +77,7 @@ class OrganizationLogSubscriber implements EventSubscriberInterface
                     '%organization%' => $organization->getName(),
                     '%user%' => $user,
                 ], 'log'),
-                $this->security->getUser()
+                $this->security->getUser()->getId()
             ));
         }
     }

--- a/src/main/log/Subscriber/FunctionalLogSubscriber.php
+++ b/src/main/log/Subscriber/FunctionalLogSubscriber.php
@@ -42,9 +42,9 @@ class FunctionalLogSubscriber implements EventSubscriberInterface
                 new \DateTime(),
                 $eventName,
                 $event->getMessage($this->translator), // this should not be done by the symfony event
-                $event->getUser(),
-                method_exists($event, 'getWorkspace') ? $event->getWorkspace() : null,
-                method_exists($event, 'getResourceNode') ? $event->getResourceNode() : null
+                $event->getUser()->getId(),
+                method_exists($event, 'getWorkspace') && $event->getWorkspace() ? $event->getWorkspace()->getId() : null,
+                method_exists($event, 'getResourceNode') && $event->getResourceNode() ? $event->getResourceNode()->getId() : null
             ));
         }
 

--- a/src/main/log/Subscriber/Security/AuthenticationLogSubscriber.php
+++ b/src/main/log/Subscriber/Security/AuthenticationLogSubscriber.php
@@ -63,8 +63,8 @@ class AuthenticationLogSubscriber implements EventSubscriberInterface
                 'username' => $event->getUser(),
             ], 'security'),
             $this->getDoerIp(),
-            $event->getUser(),
-            $event->getUser()
+            $event->getUser()->getId(),
+            $event->getUser()->getId()
         ));
     }
 
@@ -77,8 +77,8 @@ class AuthenticationLogSubscriber implements EventSubscriberInterface
                 'username' => $event->getUser(),
             ], 'security'),
             $this->getDoerIp(),
-            $event->getUser(),
-            $event->getUser()
+            $event->getUser()->getId(),
+            $event->getUser()->getId()
         ));
     }
 
@@ -92,8 +92,8 @@ class AuthenticationLogSubscriber implements EventSubscriberInterface
                 'message' => $event->getMessage(),
             ], 'security'),
             $this->getDoerIp(),
-            $event->getUser(),
-            $event->getUser()
+            $event->getUser()->getId(),
+            $event->getUser()->getId()
         ));
     }
 
@@ -107,8 +107,8 @@ class AuthenticationLogSubscriber implements EventSubscriberInterface
                 'role' => $event->getRole(),
             ], 'security'),
             $this->getDoerIp(),
-            $event->getUser(),
-            $event->getUser()
+            $event->getUser()->getId(),
+            $event->getUser()->getId()
         ));
     }
 
@@ -126,8 +126,8 @@ class AuthenticationLogSubscriber implements EventSubscriberInterface
                 'target' => $event->getTargetUser(),
             ], 'security'),
             $this->getDoerIp(),
-            $this->security->getUser(),
-            $event->getTargetUser()
+            $this->security->getUser()->getId(),
+            $event->getTargetUser()->getId()
         ));
     }
 
@@ -140,8 +140,8 @@ class AuthenticationLogSubscriber implements EventSubscriberInterface
                 'username' => $event->getUser(),
             ], 'security'),
             $this->getDoerIp(),
-            $this->security->getUser() ?? $event->getUser(),
-            $event->getUser()
+            $this->security->getUser() ? $this->security->getUser()->getId() : $event->getUser()->getId(),
+            $event->getUser()->getId()
         ));
     }
 
@@ -154,8 +154,8 @@ class AuthenticationLogSubscriber implements EventSubscriberInterface
                 'username' => $event->getUser(),
             ], 'security'),
             $this->getDoerIp(),
-            $this->security->getUser() ?? $event->getUser(),
-            $event->getUser()
+            $this->security->getUser() ? $this->security->getUser()->getId() : $event->getUser()->getId(),
+            $event->getUser()->getId()
         ));
     }
 

--- a/src/main/log/Subscriber/Security/RoleLogSubscriber.php
+++ b/src/main/log/Subscriber/Security/RoleLogSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Claroline\LogBundle\Subscriber\Security;
 
+use Claroline\CoreBundle\Entity\User;
 use Claroline\CoreBundle\Event\CatalogEvents\SecurityEvents;
 use Claroline\CoreBundle\Event\Security\AbstractRoleEvent;
 use Claroline\LogBundle\Messenger\Message\CreateRoleChangeLogs;
@@ -42,10 +43,12 @@ class RoleLogSubscriber implements EventSubscriberInterface
         $this->messageBus->dispatch(new CreateRoleChangeLogs(
             new \DateTime(),
             $eventName,
-            $event->getRole(),
+            $event->getRole()->getId(),
             $this->getDoerIp(),
-            $this->security->getUser(),
-            $event->getUsers()
+            $this->security->getUser()->getId(),
+            array_map(function (User $user) {
+                return $user->getId();
+            }, $event->getUsers())
         ));
     }
 

--- a/src/main/log/Subscriber/Security/UserLogSubscriber.php
+++ b/src/main/log/Subscriber/Security/UserLogSubscriber.php
@@ -54,8 +54,8 @@ class UserLogSubscriber implements EventSubscriberInterface
                 'username' => $event->getUser(),
             ], 'security'),
             $this->getDoerIp(),
-            $this->security->getUser() ?? $event->getUser(),
-            $event->getUser()
+            $this->security->getUser() ? $this->security->getUser()->getId() : $event->getUser()->getId(),
+            $event->getUser()->getId()
         ));
     }
 
@@ -68,8 +68,8 @@ class UserLogSubscriber implements EventSubscriberInterface
                 'username' => $event->getUser(),
             ], 'security'),
             $this->getDoerIp(),
-            $this->security->getUser() ?? $event->getUser(),
-            $event->getUser()
+            $this->security->getUser() ? $this->security->getUser()->getId() : $event->getUser()->getId(),
+            $event->getUser()->getId()
         ));
     }
 
@@ -80,8 +80,8 @@ class UserLogSubscriber implements EventSubscriberInterface
             $eventName,
             $event->getMessage($this->translator),
             $this->getDoerIp(),
-            $this->security->getUser() ?? $event->getUser(),
-            $event->getUser()
+            $this->security->getUser() ? $this->security->getUser()->getId() : $event->getUser()->getId(),
+            $event->getUser()->getId()
         ));
     }
 

--- a/src/main/transfer/Messenger/Message/ExecuteExport.php
+++ b/src/main/transfer/Messenger/Message/ExecuteExport.php
@@ -2,7 +2,9 @@
 
 namespace Claroline\TransferBundle\Messenger\Message;
 
-class ExecuteExport
+use Claroline\AppBundle\Messenger\Message\AsyncMessageInterface;
+
+class ExecuteExport implements AsyncMessageInterface
 {
     /** @var int */
     private $exportId;

--- a/src/main/transfer/Messenger/Message/ExecuteImport.php
+++ b/src/main/transfer/Messenger/Message/ExecuteImport.php
@@ -2,7 +2,9 @@
 
 namespace Claroline\TransferBundle\Messenger\Message;
 
-class ExecuteImport
+use Claroline\AppBundle\Messenger\Message\AsyncMessageInterface;
+
+class ExecuteImport implements AsyncMessageInterface
 {
     /** @var int */
     private $importId;

--- a/src/plugin/announcement/Manager/AnnouncementManager.php
+++ b/src/plugin/announcement/Manager/AnnouncementManager.php
@@ -55,9 +55,11 @@ class AnnouncementManager
         $this->messageBus->dispatch(new SendAnnouncement(
             $message['content'],
             $message['object'],
-            $message['receivers'],
+            array_map(function (User $user) {
+                return $user->getId();
+            }, $message['receivers']),
             $announcement->getId(),
-            $message['sender']
+            !empty($message['sender']) ? $message['sender']->getId() : null
         ));
     }
 

--- a/src/plugin/announcement/Messenger/Message/SendAnnouncement.php
+++ b/src/plugin/announcement/Messenger/Message/SendAnnouncement.php
@@ -3,28 +3,32 @@
 namespace Claroline\AnnouncementBundle\Messenger\Message;
 
 use Claroline\AppBundle\Messenger\Message\AsyncMessageInterface;
-use Claroline\CoreBundle\Entity\User;
 
 class SendAnnouncement implements AsyncMessageInterface
 {
+    /** @var string */
     private $content;
+    /** @var string */
     private $object;
-    private $receivers;
+    /** @var int[] */
+    private $receiverIds;
+    /** @var int */
     private $announcementId;
-    private $sender;
+    /** @var int|null */
+    private $senderId;
 
     public function __construct(
         string $content,
         string $object,
-        array $receivers,
+        array $receiverIds,
         int $announcementId,
-        ?User $sender = null
+        ?int $senderId = null
     ) {
         $this->content = $content;
         $this->object = $object;
-        $this->receivers = $receivers;
+        $this->receiverIds = $receiverIds;
         $this->announcementId = $announcementId;
-        $this->sender = $sender;
+        $this->senderId = $senderId;
     }
 
     public function getContent(): string
@@ -37,14 +41,14 @@ class SendAnnouncement implements AsyncMessageInterface
         return $this->object;
     }
 
-    public function getReceivers(): array
+    public function getReceiverIds(): array
     {
-        return $this->receivers;
+        return $this->receiverIds;
     }
 
-    public function getSender(): ?User
+    public function getSenderId(): ?int
     {
-        return $this->sender;
+        return $this->senderId;
     }
 
     public function getAnnouncementId(): int

--- a/src/plugin/claco-form/Manager/CategoryManager.php
+++ b/src/plugin/claco-form/Manager/CategoryManager.php
@@ -8,6 +8,7 @@ use Claroline\ClacoFormBundle\Entity\Entry;
 use Claroline\ClacoFormBundle\Entity\FieldChoiceCategory;
 use Claroline\ClacoFormBundle\Messenger\Message\AssignCategory;
 use Claroline\CoreBundle\Entity\Facet\FieldFacet;
+use Claroline\CoreBundle\Entity\User;
 use Claroline\CoreBundle\Messenger\Message\SendMessage;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -39,7 +40,7 @@ class CategoryManager
 
     public function assignCategory(Category $category)
     {
-        $this->messageBus->dispatch(new AssignCategory($category->getUuid()));
+        $this->messageBus->dispatch(new AssignCategory($category->getId()));
     }
 
     /**
@@ -111,7 +112,9 @@ class CategoryManager
         ], 'clacoform');
 
         $this->messageBus->dispatch(
-            new SendMessage($content, $object, $addedCategory->getManagers())
+            new SendMessage($content, $object, array_map(function (User $user) {
+                return $user->getId();
+            }, $addedCategory->getManagers()))
         );
     }
 
@@ -138,7 +141,9 @@ class CategoryManager
         ], 'clacoform');
 
         $this->messageBus->dispatch(
-            new SendMessage($content, $object, $removedCategory->getManagers())
+            new SendMessage($content, $object, array_map(function (User $user) {
+                return $user->getId();
+            }, $removedCategory->getManagers()))
         );
     }
 
@@ -173,7 +178,9 @@ class CategoryManager
             ], 'clacoform');
 
             $this->messageBus->dispatch(
-                new SendMessage($content, $object, $category->getManagers())
+                new SendMessage($content, $object, array_map(function (User $user) {
+                    return $user->getId();
+                }, $category->getManagers()))
             );
         }
     }

--- a/src/plugin/claco-form/Messenger/AssignCategoryHandler.php
+++ b/src/plugin/claco-form/Messenger/AssignCategoryHandler.php
@@ -30,9 +30,7 @@ class AssignCategoryHandler implements MessageHandlerInterface
     public function __invoke(AssignCategory $assignCategory)
     {
         // retrieve the category to check
-        $category = $this->om->getRepository(Category::class)->findOneBy([
-            'uuid' => $assignCategory->getCategoryId(),
-        ]);
+        $category = $this->om->getRepository(Category::class)->find($assignCategory->getCategoryId());
 
         if (empty($category)) {
             return;

--- a/src/plugin/claco-form/Messenger/Message/AssignCategory.php
+++ b/src/plugin/claco-form/Messenger/Message/AssignCategory.php
@@ -2,17 +2,19 @@
 
 namespace Claroline\ClacoFormBundle\Messenger\Message;
 
-class AssignCategory
+use Claroline\AppBundle\Messenger\Message\AsyncMessageInterface;
+
+class AssignCategory implements AsyncMessageInterface
 {
-    /** @var string */
+    /** @var int */
     private $categoryId;
 
-    public function __construct(string $categoryId)
+    public function __construct(int $categoryId)
     {
         $this->categoryId = $categoryId;
     }
 
-    public function getCategoryId(): string
+    public function getCategoryId(): int
     {
         return $this->categoryId;
     }

--- a/src/plugin/cursus/Manager/SessionManager.php
+++ b/src/plugin/cursus/Manager/SessionManager.php
@@ -571,7 +571,8 @@ class SessionManager
             $this->eventDispatcher->dispatch(new SendMessageEvent(
                 $content,
                 $title,
-                [$user]
+                [$user],
+                $session->getCreator()
             ), MessageEvents::MESSAGE_SENDING);
         }
     }

--- a/src/plugin/message/Resources/config/services/subscriber.yml
+++ b/src/plugin/message/Resources/config/services/subscriber.yml
@@ -3,7 +3,6 @@ services:
         arguments:
             - '@Claroline\MessageBundle\Manager\MessageManager'
             - '@doctrine.orm.entity_manager'
-            - '@security.helper'
             - '@translator'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/plugin/message/Subscriber/MessageSubscriber.php
+++ b/src/plugin/message/Subscriber/MessageSubscriber.php
@@ -17,25 +17,21 @@ use Claroline\LogBundle\Entity\MessageLog;
 use Claroline\MessageBundle\Manager\MessageManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Security\Core\Security;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class MessageSubscriber implements EventSubscriberInterface
 {
     private $messageManager;
     private $em;
-    private $security;
     private $translator;
 
     public function __construct(
         MessageManager $messageManager,
         EntityManagerInterface $em,
-        Security $security,
         TranslatorInterface $translator
     ) {
         $this->messageManager = $messageManager;
         $this->em = $em;
-        $this->security = $security;
         $this->translator = $translator;
     }
 
@@ -56,14 +52,12 @@ class MessageSubscriber implements EventSubscriberInterface
             $event->getAttachments()
         );
 
-        $sender = $event->getSender() ?? $this->security->getUser();
-
         foreach ($users as $user) {
             $logEntry = new MessageLog();
-            $logEntry->setDetails($event->getMessage($this->translator, $sender, $user));
+            $logEntry->setDetails($event->getMessage($this->translator, $event->getSender(), $user));
             $logEntry->setEvent($eventName);
             $logEntry->setReceiver($user);
-            $logEntry->setSender($sender);
+            $logEntry->setSender($event->getSender());
 
             $this->em->persist($logEntry);
         }

--- a/src/plugin/open-badge/Manager/BadgeManager.php
+++ b/src/plugin/open-badge/Manager/BadgeManager.php
@@ -75,6 +75,6 @@ class BadgeManager
 
     public function grantAll(BadgeClass $badge)
     {
-        $this->messageBus->dispatch(new GrantBadge($badge->getUuid()));
+        $this->messageBus->dispatch(new GrantBadge($badge->getId()));
     }
 }

--- a/src/plugin/open-badge/Manager/RuleManager.php
+++ b/src/plugin/open-badge/Manager/RuleManager.php
@@ -41,7 +41,7 @@ class RuleManager
 
     public function grant(Rule $rule, User $user)
     {
-        $this->messageBus->dispatch(new GrantRule($rule->getUuid(), $user->getUuid()));
+        $this->messageBus->dispatch(new GrantRule($rule->getId(), $user->getId()));
     }
 
     public function grantAll(Rule $rule): array

--- a/src/plugin/open-badge/Messenger/GrantBadgeHandler.php
+++ b/src/plugin/open-badge/Messenger/GrantBadgeHandler.php
@@ -34,7 +34,7 @@ class GrantBadgeHandler implements MessageHandlerInterface
     public function __invoke(GrantBadge $grantBadge)
     {
         /** @var BadgeClass $badge */
-        $badge = $this->om->getRepository(BadgeClass::class)->findOneBy(['uuid' => $grantBadge->getBadgeId()]);
+        $badge = $this->om->getRepository(BadgeClass::class)->find($grantBadge->getBadgeId());
         if ($badge) {
             $recomputeUsers = [];
             foreach ($badge->getRules() as $rule) {

--- a/src/plugin/open-badge/Messenger/GrantRuleHandler.php
+++ b/src/plugin/open-badge/Messenger/GrantRuleHandler.php
@@ -35,9 +35,9 @@ class GrantRuleHandler implements MessageHandlerInterface
     public function __invoke(GrantRule $grantRule)
     {
         /** @var Rule $rule */
-        $rule = $this->om->getRepository(Rule::class)->findOneBy(['uuid' => $grantRule->getRuleId()]);
+        $rule = $this->om->getRepository(Rule::class)->find($grantRule->getRuleId());
         /** @var User $user */
-        $user = $this->om->getRepository(User::class)->findOneBy(['uuid' => $grantRule->getUserId()]);
+        $user = $this->om->getRepository(User::class)->find($grantRule->getUserId());
 
         if (!empty($rule) && !empty($user)) {
             $this->ruleManager->createEvidence($rule, $user);

--- a/src/plugin/open-badge/Messenger/Message/GrantBadge.php
+++ b/src/plugin/open-badge/Messenger/Message/GrantBadge.php
@@ -2,17 +2,19 @@
 
 namespace Claroline\OpenBadgeBundle\Messenger\Message;
 
-class GrantBadge
+use Claroline\AppBundle\Messenger\Message\AsyncMessageInterface;
+
+class GrantBadge implements AsyncMessageInterface
 {
-    /** @var string */
+    /** @var int */
     private $badgeId;
 
-    public function __construct(string $badgeId)
+    public function __construct(int $badgeId)
     {
         $this->badgeId = $badgeId;
     }
 
-    public function getBadgeId(): string
+    public function getBadgeId(): int
     {
         return $this->badgeId;
     }

--- a/src/plugin/open-badge/Messenger/Message/GrantRule.php
+++ b/src/plugin/open-badge/Messenger/Message/GrantRule.php
@@ -2,26 +2,28 @@
 
 namespace Claroline\OpenBadgeBundle\Messenger\Message;
 
-class GrantRule
+use Claroline\AppBundle\Messenger\Message\AsyncMessageInterface;
+
+class GrantRule implements AsyncMessageInterface
 {
-    /** @var string */
+    /** @var int */
     private $ruleId;
 
-    /** @var string */
+    /** @var int */
     private $userId;
 
-    public function __construct(string $ruleId, string $userId)
+    public function __construct(int $ruleId, int $userId)
     {
         $this->ruleId = $ruleId;
         $this->userId = $userId;
     }
 
-    public function getRuleId(): string
+    public function getRuleId(): int
     {
         return $this->ruleId;
     }
 
-    public function getUserId(): string
+    public function getUserId(): int
     {
         return $this->userId;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

- Implement `AsyncMessageInterface` where it was missing.
- Use ids in messages instead of full entities.
- Normalize the use of auto id in messages (some messages were using uuids).