### PR TITLE
fixes doctrine/persistence version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "doctrine/doctrine-bundle": "^2.4",
         "doctrine/migrations": "^2.3",
         "doctrine/orm": "^2.8",
+        "doctrine/persistence": "2.5.3",
         "dompdf/dompdf": "*",
         "friendsofsymfony/jsrouting-bundle": "^2.2",
         "gedmo/doctrine-extensions": "^3.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

`doctrine/persistence` is not one of our direct dependency and in `3.0`, they removed the support for entity shortcuts (eg. ClarolineCoreBundle:User).