### PR TITLE
[Messenger] stores logs in a specific file

### DIFF
--- a/src/main/app/Resources/config/suggested/monolog_dev.yml
+++ b/src/main/app/Resources/config/suggested/monolog_dev.yml
@@ -4,9 +4,15 @@ monolog:
             type:  stream
             path:  "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug
-            channels: ["!event"]
+            channels: ["!event", "!messenger"]
 
         console:
             type: console
             process_psr_3_messages: false
             channels: ["!php", "!event", "!doctrine", "!console"]
+
+        messenger:
+            type: stream
+            path: "%kernel.logs_dir%/messenger.log"
+            level: debug
+            channels: [ "messenger" ]

--- a/src/main/app/Resources/config/suggested/monolog_prod.yml
+++ b/src/main/app/Resources/config/suggested/monolog_prod.yml
@@ -10,8 +10,15 @@ monolog:
             type:  stream
             path:  "%kernel.logs_dir%/%kernel.environment%.log"
             level: error
+            channels: ["!messenger"]
 
         console:
             type: console
             process_psr_3_messages: false
             channels: [ "!php", "!event", "!doctrine" ]
+
+        messenger:
+            type: stream
+            path: "%kernel.logs_dir%/messenger.log"
+            level: error
+            channels: ["messenger"]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no

The new log file is named `messenger.log`.

NB. I've excluded the `messenger` channel from the main stream, but I'm not sure this was required (I did not find any messenger log in the main files).


