### PR TITLE
fixes DateNormalizer::denormalize return type

### DIFF
--- a/src/main/core/Library/Normalizer/DateNormalizer.php
+++ b/src/main/core/Library/Normalizer/DateNormalizer.php
@@ -31,7 +31,10 @@ class DateNormalizer
     {
         if (!empty($dateString)) {
             try {
-                return \DateTime::createFromFormat(static::DATE_FORMAT, $dateString);
+                $dateObject = \DateTime::createFromFormat(static::DATE_FORMAT, trim($dateString));
+                if (false !== $dateObject) {
+                    return $dateObject;
+                }
             } catch (\Exception $e) {
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

`DateTime::createFromFormat(static::DATE_FORMAT, $dateString)` returns `false` on failure and the `denormalize` method is expected to return `?\DatetimeInterface`
