### PR TITLE
[Resource] links evaluated flag to the required one in form

### DIFF
--- a/src/main/core/Resources/modules/resource/components/form.jsx
+++ b/src/main/core/Resources/modules/resource/components/form.jsx
@@ -184,12 +184,21 @@ const ResourceFormComponent = (props) =>
             name: 'evaluation.required',
             label: trans('require_resource', {}, 'resource'),
             type: 'boolean',
-            help: trans('require_resource_help', {}, 'resource')
-          }, {
-            name: 'evaluation.evaluated',
-            label: trans('evaluate_resource', {}, 'resource'),
-            type: 'boolean',
-            help: trans('evaluate_resource_help', {}, 'resource')
+            help: trans('require_resource_help', {}, 'resource'),
+            onChange: (required) => {
+              if (!required) {
+                props.updateProp('evaluation.evaluated', false)
+              }
+            },
+            linked: [
+              {
+                name: 'evaluation.evaluated',
+                label: trans('evaluate_resource', {}, 'resource'),
+                type: 'boolean',
+                help: trans('evaluate_resource_help', {}, 'resource'),
+                displayed: (resource) => get(resource, 'evaluation.required', false)
+              }
+            ]
           }
         ]
       }, {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

![Sans titre-1](https://user-images.githubusercontent.com/5363219/195774957-ddac1c98-af80-48c3-a121-20646230976f.png)

That's how the API works : we don't update the workspace score if the resource is not required.
