### PR TITLE
[UI] hides configure rights button in more dropdown

### DIFF
--- a/src/main/core/Resources/modules/resource/utils.js
+++ b/src/main/core/Resources/modules/resource/utils.js
@@ -142,7 +142,7 @@ function getDefaultAction(resourceNode, nodesRefresher, path, currentUser = null
  * @return {string}
  */
 function getToolbar(primaryAction = null) {
-  let toolbar = 'edit rights publish unpublish'
+  let toolbar = 'edit publish unpublish'
   if (primaryAction) {
     toolbar = primaryAction + ' | ' + toolbar
   }

--- a/src/main/core/Resources/modules/tool/components/page.jsx
+++ b/src/main/core/Resources/modules/tool/components/page.jsx
@@ -12,7 +12,7 @@ import {CALLBACK_BUTTON} from '#/main/app/buttons'
 import classes from 'classnames'
 
 const ToolPage = props => {
-  let toolbar = 'edit rights'
+  let toolbar = 'edit'
   if (props.primaryAction) {
     toolbar = props.primaryAction + ' | ' + toolbar
   }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no

Initially the rights button was put outside the dropdown because it was displaying a simplified version of the rights through the icon. This behavior has been removed, so there is no need to separate it from the Configure action.