### PR TITLE
fixes RichTextCommand when some plugins are disabled

### DIFF
--- a/src/main/core/Command/UpdateRichTextCommand.php
+++ b/src/main/core/Command/UpdateRichTextCommand.php
@@ -182,7 +182,7 @@ class UpdateRichTextCommand extends Command
 
     private function getParsableEntities()
     {
-        return [
+        return array_filter([
             'Claroline\CoreBundle\Entity\Content' => ['content'],
             'Claroline\CoreBundle\Entity\Resource\Revision' => ['content'],
             'Claroline\CoreBundle\Entity\Widget\Type\SimpleWidget' => ['content'],
@@ -199,6 +199,8 @@ class UpdateRichTextCommand extends Command
             'Claroline\CursusBundle\Entity\Session' => ['description'],
             'HeVinci\UrlBundle\Entity\Url' => ['url'],
             'HeVinci\UrlBundle\Entity\Home\UrlTab' => ['url'],
-        ];
+        ], function (string $className) {
+            return class_exists($className);
+        }, ARRAY_FILTER_USE_KEY);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

Basic version. The correct version is to use events.