### PR TITLE
uses local tmp dir

### DIFF
--- a/src/main/app/Manager/File/TempFileManager.php
+++ b/src/main/app/Manager/File/TempFileManager.php
@@ -2,27 +2,27 @@
 
 namespace Claroline\AppBundle\Manager\File;
 
-use Claroline\CoreBundle\Library\Configuration\PlatformConfigurationHandler;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\File;
 
 class TempFileManager
 {
-    /** @var PlatformConfigurationHandler */
-    private $config;
+    /** @var string */
+    private $tmpDir;
 
     /**
      * The list of current temp files.
+     * This is used to purge the temp files created during the process of the current request.
      *
      * @var array
      */
     private $files = [];
 
     public function __construct(
-        PlatformConfigurationHandler $config)
-    {
-        $this->config = $config;
+        string $tmpDir
+    ) {
+        $this->tmpDir = $tmpDir;
     }
 
     /**
@@ -30,7 +30,12 @@ class TempFileManager
      */
     public function getDirectory(): string
     {
-        return $this->config->getParameter('tmp_dir');
+        $fs = new Filesystem();
+        if (!$fs->exists($this->tmpDir)) {
+            $fs->mkdir($this->tmpDir);
+        }
+
+        return $this->tmpDir;
     }
 
     /**

--- a/src/main/app/Resources/config/services/manager.yml
+++ b/src/main/app/Resources/config/services/manager.yml
@@ -28,6 +28,7 @@ services:
 
     Claroline\AppBundle\Manager\File\TempFileManager:
         arguments:
+            - '%claroline.tmp_dir%'
             - '@Claroline\CoreBundle\Library\Configuration\PlatformConfigurationHandler'
 
     Claroline\AppBundle\Manager\TermsOfServiceManager:

--- a/src/main/core/Configuration/LegacyParametersMapping.php
+++ b/src/main/core/Configuration/LegacyParametersMapping.php
@@ -59,7 +59,6 @@ class LegacyParametersMapping implements LegacyParametersMappingInterface
             'ssl_enabled' => 'ssl.enabled',
             'ssl_version_value' => 'ssl.version',
             'enable_opengraph' => 'text.enable_opengraph',
-            'tmp_dir' => 'server.tmp_dir',
             'resource_icon_set' => 'display.resource_icon_set',
             'direct_third_party_authentication' => 'authentication.direct_third_party',
             'platform_log_enabled' => 'logs.enabled',

--- a/src/main/core/Configuration/PlatformDefaults.php
+++ b/src/main/core/Configuration/PlatformDefaults.php
@@ -116,9 +116,6 @@ class PlatformDefaults implements ParameterProviderInterface
                 'enabled' => false,
                 'version' => 3,
             ],
-            'server' => [
-                'tmp_dir' => sys_get_temp_dir(),
-            ],
             'auto_enable_notifications' => [
                 'resource-create' => ['visible'],
                 'resource-publish' => ['visible'],

--- a/src/main/core/Library/GeoIp/Database/MaxMindGeoIpDatabaseDownloader.php
+++ b/src/main/core/Library/GeoIp/Database/MaxMindGeoIpDatabaseDownloader.php
@@ -22,13 +22,18 @@ class MaxMindGeoIpDatabaseDownloader
     private $filesystem;
     private $tempDir;
 
-    public function __construct(?LoggerInterface $logger = null, ?HttpClientInterface $httpClient = null, ?Filesystem $filesystem = null, PlatformConfigurationHandler $config)
-    {
+    public function __construct(
+        PlatformConfigurationHandler $config,
+        string $tempDir,
+        ?LoggerInterface $logger = null,
+        ?HttpClientInterface $httpClient = null,
+        ?Filesystem $filesystem = null
+    ) {
         $this->licenseKey = $config->getParameter('geoip.maxmind_license_key');
         $this->logger = $logger ?? new NullLogger();
         $this->httpClient = $httpClient ?? HttpClient::create();
         $this->filesystem = $filesystem ?? new Filesystem();
-        $this->tempDir = $config->getParameter('server.tmp_dir') ?? sys_get_temp_dir();
+        $this->tempDir = $tempDir;
     }
 
     public function downloadDatabase(string $destinationDir, bool $catchExceptions = true): void

--- a/src/main/core/Resources/config/parameters.yml
+++ b/src/main/core/Resources/config/parameters.yml
@@ -6,7 +6,7 @@ parameters:
     test.client.class: Claroline\CoreBundle\Library\Testing\TransactionalTestClient
 
     # Project base paths
-    claroline.param.vendor_directory: "%kernel.project_dir%/vendor"
+    claroline.tmp_dir:                "%kernel.project_dir%/var/tmp"
     claroline.param.public_directory: "%kernel.project_dir%/public"
     claroline.param.files_directory:  "%kernel.project_dir%/files"
 

--- a/src/main/core/Resources/config/services/library.yml
+++ b/src/main/core/Resources/config/services/library.yml
@@ -90,10 +90,11 @@ services:
     # GeoIp
     Claroline\CoreBundle\Library\GeoIp\Database\MaxMindGeoIpDatabaseDownloader:
         arguments:
+            - '@Claroline\CoreBundle\Library\Configuration\PlatformConfigurationHandler'
+            - '%claroline.tmp_dir%'
             - '@logger'
             - '@?http_client'
             - '@filesystem'
-            - '@Claroline\CoreBundle\Library\Configuration\PlatformConfigurationHandler'
 
     Claroline\CoreBundle\Library\GeoIp\MaxMindGeoIpInfoProvider:
         arguments: ['@GeoIp2\Database\Reader']

--- a/src/plugin/claco-form/Manager/ExportManager.php
+++ b/src/plugin/claco-form/Manager/ExportManager.php
@@ -2,6 +2,7 @@
 
 namespace Claroline\ClacoFormBundle\Manager;
 
+use Claroline\AppBundle\Manager\File\TempFileManager;
 use Claroline\AppBundle\Manager\PdfManager;
 use Claroline\ClacoFormBundle\Entity\ClacoForm;
 use Claroline\ClacoFormBundle\Entity\Comment;
@@ -9,11 +10,9 @@ use Claroline\ClacoFormBundle\Entity\Entry;
 use Claroline\ClacoFormBundle\Entity\Field;
 use Claroline\CoreBundle\Entity\Facet\FieldFacet;
 use Claroline\CoreBundle\Entity\User;
-use Claroline\CoreBundle\Library\Configuration\PlatformConfigurationHandler;
 use Claroline\CoreBundle\Library\Normalizer\DateNormalizer;
 use Claroline\CoreBundle\Library\Normalizer\TextNormalizer;
 use Claroline\CoreBundle\Manager\LocationManager;
-use Ramsey\Uuid\Uuid;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -25,8 +24,8 @@ class ExportManager
     private $router;
     /** @var ClacoFormManager */
     private $clacoFormManager;
-    /** @var PlatformConfigurationHandler */
-    private $configHandler;
+    /** @var TempFileManager */
+    private $tempManager;
     /** @var string */
     private $filesDir;
     /** @var LocationManager */
@@ -41,7 +40,7 @@ class ExportManager
     public function __construct(
         RouterInterface $router,
         ClacoFormManager $clacoFormManager,
-        PlatformConfigurationHandler $configHandler,
+        TempFileManager $tempManager,
         string $filesDir,
         LocationManager $locationManager,
         Environment $templating,
@@ -50,7 +49,7 @@ class ExportManager
     ) {
         $this->router = $router;
         $this->clacoFormManager = $clacoFormManager;
-        $this->configHandler = $configHandler;
+        $this->tempManager = $tempManager;
         $this->filesDir = $filesDir;
         $this->locationManager = $locationManager;
         $this->templating = $templating;
@@ -170,7 +169,7 @@ class ExportManager
     public function zipEntries($content, ClacoForm $clacoForm)
     {
         $archive = new \ZipArchive();
-        $pathArch = $this->configHandler->getParameter('tmp_dir').DIRECTORY_SEPARATOR.Uuid::uuid4()->toString().'.zip';
+        $pathArch = $this->tempManager->generate();
         $archive->open($pathArch, \ZipArchive::CREATE);
         $archive->addFromString($clacoForm->getResourceNode()->getName().'.xls', $content);
 

--- a/src/plugin/claco-form/Resources/config/services/manager.yml
+++ b/src/plugin/claco-form/Resources/config/services/manager.yml
@@ -29,7 +29,7 @@ services:
         arguments:
             - '@router'
             - '@Claroline\ClacoFormBundle\Manager\ClacoFormManager'
-            - '@Claroline\CoreBundle\Library\Configuration\PlatformConfigurationHandler'
+            - '@Claroline\AppBundle\Manager\File\TempFileManager'
             - '%claroline.param.files_directory%'
             - '@Claroline\CoreBundle\Manager\LocationManager'
             - '@twig'

--- a/src/plugin/drop-zone/Manager/DropzoneManager.php
+++ b/src/plugin/drop-zone/Manager/DropzoneManager.php
@@ -13,9 +13,9 @@ namespace Claroline\DropZoneBundle\Manager;
 
 use Claroline\AppBundle\API\Options;
 use Claroline\AppBundle\API\SerializerProvider;
+use Claroline\AppBundle\Manager\File\TempFileManager;
 use Claroline\AppBundle\Persistence\ObjectManager;
 use Claroline\CoreBundle\Entity\User;
-use Claroline\CoreBundle\Library\Configuration\PlatformConfigurationHandler;
 use Claroline\DropZoneBundle\Entity\Criterion;
 use Claroline\DropZoneBundle\Entity\Document;
 use Claroline\DropZoneBundle\Entity\Drop;
@@ -39,8 +39,8 @@ class DropzoneManager
     private $filesDir;
     /** @var ObjectManager */
     private $om;
-    /** @var PlatformConfigurationHandler */
-    private $configHandler;
+    /** @var TempFileManager */
+    private $tempManager;
     /** @var SerializerProvider */
     private $serializer;
     /** @var TeamManager */
@@ -58,7 +58,7 @@ class DropzoneManager
     public function __construct(
         string $filesDir,
         ObjectManager $om,
-        PlatformConfigurationHandler $configHandler,
+        TempFileManager $tempManager,
         EventDispatcherInterface $eventDispatcher,
         TranslatorInterface $translator,
         SerializerProvider $serializer,
@@ -68,7 +68,7 @@ class DropzoneManager
     ) {
         $this->filesDir = $filesDir;
         $this->om = $om;
-        $this->configHandler = $configHandler;
+        $this->tempManager = $tempManager;
         $this->eventDispatcher = $eventDispatcher;
         $this->translator = $translator;
         $this->serializer = $serializer;
@@ -342,7 +342,7 @@ class DropzoneManager
     {
         $ds = DIRECTORY_SEPARATOR;
         $archive = new \ZipArchive();
-        $pathArch = $this->configHandler->getParameter('tmp_dir').$ds.Uuid::uuid4()->toString().'.zip';
+        $pathArch = $this->tempManager->generate();
         $archive->open($pathArch, \ZipArchive::CREATE);
 
         foreach ($drops as $drop) {
@@ -369,7 +369,7 @@ class DropzoneManager
                         break;
                     case Document::DOCUMENT_TYPE_TEXT:
                         $name = 'text_'.Uuid::uuid4()->toString().'.html';
-                        $textPath = $this->configHandler->getParameter('tmp_dir').$ds.$name;
+                        $textPath = $this->tempManager->generate();
                         file_put_contents($textPath, $document->getData());
                         $archive->addFile(
                             $textPath,
@@ -378,7 +378,7 @@ class DropzoneManager
                         break;
                     case Document::DOCUMENT_TYPE_URL:
                         $name = 'url_'.Uuid::uuid4()->toString();
-                        $textPath = $this->configHandler->getParameter('tmp_dir').$ds.$name;
+                        $textPath = $this->tempManager->generate();
                         file_put_contents($textPath, $document->getData());
                         $archive->addFile(
                             $textPath,

--- a/src/plugin/drop-zone/Resources/config/services/manager.yml
+++ b/src/plugin/drop-zone/Resources/config/services/manager.yml
@@ -24,7 +24,7 @@ services:
         arguments:
             - '%claroline.param.files_directory%'
             - '@Claroline\AppBundle\Persistence\ObjectManager'
-            - '@Claroline\CoreBundle\Library\Configuration\PlatformConfigurationHandler'
+            - '@Claroline\AppBundle\Manager\File\TempFileManager'
             - '@event_dispatcher'
             - '@translator'
             - '@Claroline\AppBundle\API\SerializerProvider'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no

Tmp dir is now declared as a symfony parameter. This shouldn't be stored in `platform_options`.
We now use `/var/tmp` to store tmp files instead of the system one (default was set to `sys_get_temp_dir()`). This can create some security issued and also require to read/write inside a big folder.