### PR TITLE
[Transfer] flushes each import line

### DIFF
--- a/src/main/transfer/Transfer/Importer/AbstractImporter.php
+++ b/src/main/transfer/Transfer/Importer/AbstractImporter.php
@@ -22,7 +22,7 @@ abstract class AbstractImporter implements ImporterInterface
 
     public function getBatchSize(): int
     {
-        return 100;
+        return 1;
     }
 
     public function getMode()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

If import lines are related to the same entity, there are special cases where the system will try to insert multiple times the same entities (ex. generate resource evaluations).
