### PR TITLE
[Documentation] adds plugin in .ini

### DIFF
--- a/docs/sections/application/plugins.md
+++ b/docs/sections/application/plugins.md
@@ -55,12 +55,11 @@ plugin: ~
 ```
 
 and you must declare in bundles.ini file ``files/config/bundles.ini`` the plugin name and the bundle class name :
-
 ```ini
-### The composer autoloading **[required]**
 Claroline\YourPluginBundle\ClarolineYourPlugingBundle=true
 ```
 
+### The composer autoloading **[required]**
 Claroline Connect uses a custom directory structure which don't fully follow the PSR-4 rules 
 (there are additional directories before the PSR-4 can be applied).
 

--- a/docs/sections/application/plugins.md
+++ b/docs/sections/application/plugins.md
@@ -54,7 +54,12 @@ This file is located in `your_plugin/Resources/config/config.yml`.
 plugin: ~
 ```
 
+and you must declare in bundles.ini file ``files/config/bundles.ini`` the plugin name and the bundle class name :
+
+```ini
 ### The composer autoloading **[required]**
+Claroline\YourPluginBundle\ClarolineYourPlugingBundle=true
+```
 
 Claroline Connect uses a custom directory structure which don't fully follow the PSR-4 rules 
 (there are additional directories before the PSR-4 can be applied).


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Fixed issues | comma-separated list of issues fixed by the PR, if any

<!-- Description -->
Added in the doc section application/plugins.md the missing instruction concerning the bundles.ini file: 

``files/config/bundles.ini``  -> ``Claroline\YourPluginBundle\ClarolineYourPlugingBundle=true``

