### PR TITLE
fixes exception status forward

### DIFF
--- a/src/main/app/Listener/ApiListener.php
+++ b/src/main/app/Listener/ApiListener.php
@@ -57,8 +57,7 @@ class ApiListener
                 $response = new JsonResponse([
                     'message' => $exception->getMessage(),
                     'trace' => $exception->getTrace(),
-                    //if <200, not http error code
-                ], $exception->getCode() < 200 ? 500 : $exception->getCode());
+                ], $exception->getCode() < 100 || $exception->getCode() >= 600 ? 500 : $exception->getCode());
 
                 $event->setResponse($response);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

Some Doctrine error codes where wrongly forwarded as HTTP status code.

NB. The check seems a little weak but it's the same than `Symfony\Component\HttpFoundation\Response::isInvalid()`