### PR TITLE
[YouTube] fixes plugin auto activation

### DIFF
--- a/src/main/installation/Resources/config/bundles.ini-dist
+++ b/src/main/installation/Resources/config/bundles.ini-dist
@@ -46,6 +46,6 @@ Claroline\AudioPlayerBundle\ClarolineAudioPlayerBundle = true
 Claroline\CursusBundle\ClarolineCursusBundle = true
 Claroline\BigBlueButtonBundle\ClarolineBigBlueButtonBundle = false
 Claroline\PeerTubeBundle\ClarolinePeerTubeBundle = false
-Claroline\\YouTubeBundle\\ClarolineYouTubeBundle = true
+Claroline\YouTubeBundle\ClarolineYouTubeBundle = true
 Claroline\LogBundle\ClarolineLogBundle=true
 Claroline\PrivacyBundle\ClarolinePrivacyBundle=true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

A cause de l'échappement, le plugin n'était pas reconnu pas le kernel lors de l'activation automatique via le `bundle.ini-dist`

ping @WolfyWin FYI.