### PR TITLE
[Community] Enhanced team and role management

### DIFF
--- a/src/main/community/Controller/TeamController.php
+++ b/src/main/community/Controller/TeamController.php
@@ -64,6 +64,7 @@ class TeamController extends AbstractCrudController
 
     /**
      * @Route("/workspace/{id}/teams", name="apiv2_workspace_team_list", methods={"GET"})
+     *
      * @EXT\ParamConverter("workspace", class="Claroline\CoreBundle\Entity\Workspace\Workspace", options={"mapping": {"id": "uuid"}})
      */
     public function listByWorkspaceAction(Workspace $workspace, Request $request): JsonResponse
@@ -83,6 +84,7 @@ class TeamController extends AbstractCrudController
 
     /**
      * @Route("/{id}/users/{role}", name="apiv2_team_list_users", methods={"GET"})
+     *
      * @EXT\ParamConverter("team", class="Claroline\CommunityBundle\Entity\Team", options={"mapping": {"id": "uuid"}})
      * @EXT\ParamConverter("user", converter="current_user", options={"allowAnonymous"=true})
      */
@@ -111,6 +113,7 @@ class TeamController extends AbstractCrudController
 
     /**
      * @Route("/{id}/users/{role}", name="apiv2_team_register", methods={"PATCH"})
+     *
      * @EXT\ParamConverter("team", class="Claroline\CommunityBundle\Entity\Team", options={"mapping": {"id": "uuid"}})
      */
     public function registerAction(Team $team, string $role, Request $request): JsonResponse
@@ -148,6 +151,7 @@ class TeamController extends AbstractCrudController
 
     /**
      * @Route("/{id}/users/{role}", name="apiv2_team_unregister", methods={"DELETE"})
+     *
      * @EXT\ParamConverter("team", class="Claroline\CommunityBundle\Entity\Team", options={"mapping": {"id": "uuid"}})
      */
     public function unregisterAction(Team $team, string $role, Request $request): JsonResponse
@@ -167,6 +171,7 @@ class TeamController extends AbstractCrudController
 
     /**
      * @Route("/{id}/register", name="apiv2_team_self_register", methods={"PUT"})
+     *
      * @EXT\ParamConverter("team", class="Claroline\CommunityBundle\Entity\Team", options={"mapping": {"id": "uuid"}})
      * @EXT\ParamConverter("user", converter="current_user", options={"allowAnonymous"=false})
      */
@@ -196,6 +201,7 @@ class TeamController extends AbstractCrudController
 
     /**
      * @Route("/{id}/unregister", name="apiv2_team_self_unregister", methods={"DELETE"})
+     *
      * @EXT\ParamConverter("team", class="Claroline\CommunityBundle\Entity\Team", options={"mapping": {"id": "uuid"}})
      * @EXT\ParamConverter("user", converter="current_user", options={"allowAnonymous"=false})
      */

--- a/src/main/community/Controller/TeamController.php
+++ b/src/main/community/Controller/TeamController.php
@@ -90,9 +90,10 @@ class TeamController extends AbstractCrudController
     {
         $this->checkPermission('OPEN', $team, [], true);
 
-        $hiddenFilters = [
-            'role' => ['manager' === $role ? $team->getManagerRole()->getUuid() : $team->getRole()->getUuid()],
-        ];
+        $hiddenFilters = [];
+
+        $role = 'manager' === $role ? $team->getManagerRole() : $team->getRole();
+        $hiddenFilters['role'] = $role?->getUuid();
 
         if (!$this->checkPermission('ROLE_ADMIN')) {
             // only list users for the current user organizations

--- a/src/main/community/Entity/Team.php
+++ b/src/main/community/Entity/Team.php
@@ -46,7 +46,7 @@ class Team
     private $workspace;
 
     /**
-     * @ORM\OneToOne(targetEntity="Claroline\CoreBundle\Entity\Role", cascade={"remove"})
+     * @ORM\OneToOne(targetEntity="Claroline\CoreBundle\Entity\Role")
      * @ORM\JoinColumn(nullable=true, onDelete="SET NULL")
      *
      * @var Role
@@ -62,7 +62,7 @@ class Team
     private $users;
 
     /**
-     * @ORM\OneToOne(targetEntity="Claroline\CoreBundle\Entity\Role", cascade={"remove"})
+     * @ORM\OneToOne(targetEntity="Claroline\CoreBundle\Entity\Role")
      * @ORM\JoinColumn(name="manager_role_id", nullable=true, onDelete="SET NULL")
      *
      * @var Role
@@ -104,6 +104,13 @@ class Team
      * @var bool
      */
     private $isPublic = false;
+
+    /**
+     * @ORM\Column(name="is_using_existing_roles", type="boolean")
+     *
+     * @var bool
+     */
+    private $isUsingExistingRoles = false;
 
     /**
      * @ORM\Column(name="dir_deletable", type="boolean", options={"default" = 0})
@@ -234,5 +241,15 @@ class Team
     public function setDirDeletable(bool $dirDeletable): void
     {
         $this->dirDeletable = $dirDeletable;
+    }
+
+    public function isUsingExistingRoles(): bool
+    {
+        return $this->isUsingExistingRoles;
+    }
+
+    public function setIsUsingExistingRoles(bool $isUsingExistingRoles): void
+    {
+        $this->isUsingExistingRoles = $isUsingExistingRoles;
     }
 }

--- a/src/main/community/Entity/Team.php
+++ b/src/main/community/Entity/Team.php
@@ -26,6 +26,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Table(name="claro_team")
+ *
  * @ORM\Entity(repositoryClass="Claroline\CommunityBundle\Repository\TeamRepository")
  */
 class Team
@@ -39,6 +40,7 @@ class Team
 
     /**
      * @ORM\ManyToOne(targetEntity="Claroline\CoreBundle\Entity\Workspace\Workspace")
+     *
      * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
      *
      * @var Workspace
@@ -47,6 +49,7 @@ class Team
 
     /**
      * @ORM\OneToOne(targetEntity="Claroline\CoreBundle\Entity\Role")
+     *
      * @ORM\JoinColumn(nullable=true, onDelete="SET NULL")
      *
      * @var Role
@@ -55,6 +58,7 @@ class Team
 
     /**
      * @ORM\ManyToMany(targetEntity="Claroline\CoreBundle\Entity\User")
+     *
      * @ORM\JoinTable(name="claro_team_users")
      *
      * @var ArrayCollection|User[]
@@ -63,6 +67,7 @@ class Team
 
     /**
      * @ORM\OneToOne(targetEntity="Claroline\CoreBundle\Entity\Role")
+     *
      * @ORM\JoinColumn(name="manager_role_id", nullable=true, onDelete="SET NULL")
      *
      * @var Role
@@ -92,6 +97,7 @@ class Team
 
     /**
      * @ORM\OneToOne(targetEntity="Claroline\CoreBundle\Entity\Resource\ResourceNode")
+     *
      * @ORM\JoinColumn(nullable=true, onDelete="SET NULL")
      *
      * @var ResourceNode
@@ -178,7 +184,7 @@ class Team
         return $this->managerRole;
     }
 
-    public function setManagerRole(?Role $managerRole = null): void
+    public function setManagerRole(Role $managerRole = null): void
     {
         $this->managerRole = $managerRole;
     }
@@ -188,7 +194,7 @@ class Team
         return $this->maxUsers;
     }
 
-    public function setMaxUsers(?int $maxUsers = null): void
+    public function setMaxUsers(int $maxUsers = null): void
     {
         $this->maxUsers = $maxUsers;
     }
@@ -218,7 +224,7 @@ class Team
         return $this->directory;
     }
 
-    public function setDirectory(?ResourceNode $directory = null)
+    public function setDirectory(ResourceNode $directory = null)
     {
         $this->directory = $directory;
     }

--- a/src/main/community/Installation/Migrations/Version20230823120235.php
+++ b/src/main/community/Installation/Migrations/Version20230823120235.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Claroline\CommunityBundle\Installation\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated migration based on mapping information: modify it with caution.
+ *
+ * Generation date: 2023/08/23 12:02:36
+ */
+final class Version20230823120235 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('
+            ALTER TABLE claro_team 
+            ADD is_using_existing_roles TINYINT(1) NOT NULL
+        ');
+        $this->addSql('
+            ALTER TABLE claro_team 
+            DROP FOREIGN KEY FK_A2FE5804D60322AC
+        ');
+        $this->addSql('
+            ALTER TABLE claro_team 
+            DROP INDEX UNIQ_A2FE5804D60322AC
+        ');
+        $this->addSql('
+            ALTER TABLE claro_team 
+            DROP FOREIGN KEY FK_A2FE580468CE17BA
+        ');
+        $this->addSql('
+            ALTER TABLE claro_team 
+            DROP INDEX UNIQ_A2FE580468CE17BA
+        ');
+
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('
+            ALTER TABLE claro_team 
+            DROP is_using_existing_roles
+        ');
+        $this->addSql('
+            ALTER TABLE claro_team 
+            ADD CONSTRAINT FK_A2FE5804D60322AC FOREIGN KEY (role_id) 
+            REFERENCES claro_role (id) 
+            ON DELETE SET NULL
+        ');
+        $this->addSql('
+            ALTER TABLE claro_team 
+            ADD UNIQUE INDEX UNIQ_A2FE5804D60322AC (role_id)
+        ');
+        $this->addSql('
+            ALTER TABLE claro_team 
+            ADD CONSTRAINT FK_A2FE580468CE17BA FOREIGN KEY (manager_role_id) 
+            REFERENCES claro_role (id) 
+            ON DELETE SET NULL
+        ');
+        $this->addSql('
+            ALTER TABLE claro_team 
+            ADD UNIQUE INDEX UNIQ_A2FE580468CE17BA (manager_role_id)
+        ');
+    }
+}

--- a/src/main/community/Installation/Migrations/Version20230823120235.php
+++ b/src/main/community/Installation/Migrations/Version20230823120235.php
@@ -34,7 +34,6 @@ final class Version20230823120235 extends AbstractMigration
             ALTER TABLE claro_team 
             DROP INDEX UNIQ_A2FE580468CE17BA
         ');
-
     }
 
     public function down(Schema $schema): void

--- a/src/main/community/Manager/TeamManager.php
+++ b/src/main/community/Manager/TeamManager.php
@@ -111,7 +111,7 @@ class TeamManager
     /**
      * Creates team directory.
      */
-    public function createTeamDirectory(Team $team, User $user, ?ResourceNode $resource = null, ?array $creatableResources = []): Directory
+    public function createTeamDirectory(Team $team, User $user, ResourceNode $resource = null, ?array $creatableResources = []): Directory
     {
         $workspace = $team->getWorkspace();
 

--- a/src/main/community/Manager/TeamManager.php
+++ b/src/main/community/Manager/TeamManager.php
@@ -95,15 +95,17 @@ class TeamManager
 
     public function deleteTeamRoles(Team $team): void
     {
-        if (!empty($team->getRole())) {
-            $this->om->remove($team->getRole());
-        }
+        if (!$team->isUsingExistingRoles()) {
+            if (!empty($team->getRole())) {
+                $this->om->remove($team->getRole());
+            }
 
-        if (!empty($team->getManagerRole())) {
-            $this->om->remove($team->getManagerRole());
-        }
+            if (!empty($team->getManagerRole())) {
+                $this->om->remove($team->getManagerRole());
+            }
 
-        $this->om->flush();
+            $this->om->flush();
+        }
     }
 
     /**

--- a/src/main/community/Resources/modules/team/components/form.jsx
+++ b/src/main/community/Resources/modules/team/components/form.jsx
@@ -50,6 +50,43 @@ const TeamFormComponent = props =>
           }
         ]
       }, {
+        icon: 'fa fa-fw fa-chess',
+        title: trans('roles'),
+        fields: [{
+          name: 'isUsingExistingRoles',
+          type: 'boolean',
+          label: trans('use_existing_roles', {}, 'community'),
+          help: trans('use_existing_roles_help', {}, 'community'),
+          onChange: (value) => {
+            if (!value) {
+              props.updateProp('role', null)
+              props.updateProp('managerRole', null)
+            }
+          }
+        }, {
+          name: 'role',
+          type: 'role',
+          label: trans('role', {}, 'community'),
+          displayed: (team) => team.isUsingExistingRoles,
+          options: team => ({
+            picker: {
+              url: ['apiv2_workspace_list_roles', {id: get(team, 'workspace.id', null)}],
+              filters: []
+            }
+          })
+        }, {
+          name: 'managerRole',
+          type: 'role',
+          label: trans('manager_role', {}, 'community'),
+          displayed: (team) => team.isUsingExistingRoles,
+          options: team => ({
+            picker: {
+              url: ['apiv2_workspace_list_roles', {id: get(team, 'workspace.id', null)}],
+              filters: []
+            }
+          })
+        }]
+      }, {
         icon: 'fa fa-fw fa-desktop',
         title: trans('display_parameters'),
         fields: [

--- a/src/main/community/Resources/modules/team/prop-types.js
+++ b/src/main/community/Resources/modules/team/prop-types.js
@@ -39,6 +39,7 @@ const Team = {
     managerRole: T.shape(
       RoleTypes.propTypes
     ),
+    isUsingExistingRoles: T.bool.isRequired,
     directory: T.shape(
       ResourceNodeTypes.propTypes
     )

--- a/src/main/community/Resources/translations/community.en.json
+++ b/src/main/community/Resources/translations/community.en.json
@@ -53,6 +53,8 @@
   "delete_team_directory": "Delete team's directory at team deletion",
   "team_creatable_resources": "Resources that can be created by users",
   "team_default_resource": "Default resource",
+  "use_existing_roles": "Use existing roles",
+  "use_existing_roles_help": "If enabled, existing roles will be used for teams. Otherwise, team-specific roles will be created.",
 
   "user": "User",
   "users": "Users",

--- a/src/main/community/Resources/translations/community.fr.json
+++ b/src/main/community/Resources/translations/community.fr.json
@@ -53,6 +53,8 @@
   "delete_team_directory": "Supprimer le dossier à la suppression de l'équipe",
   "team_creatable_resources": "Ressources pouvant être créées par les utilisateurs",
   "team_default_resource": "Ressource par défaut",
+  "use_existing_roles": "Utiliser des rôles existants",
+  "use_existing_roles_help": "Si activé, des rôles existants seront utilisés pour les équipes. Sinon, des rôles spécifiques aux équipes seront créés.",
 
   "user": "Utilisateur",
   "users": "Utilisateurs",

--- a/src/main/community/Serializer/TeamSerializer.php
+++ b/src/main/community/Serializer/TeamSerializer.php
@@ -69,6 +69,7 @@ class TeamSerializer
             'name' => $team->getName(),
             'thumbnail' => $team->getThumbnail(),
             'poster' => $team->getPoster(),
+            'isUsingExistingRoles' => $team->isUsingExistingRoles(),
             'users' => $this->om->getRepository(Team::class)->countUsers($team),
             'meta' => [
                 'description' => $team->getDescription(),
@@ -127,6 +128,7 @@ class TeamSerializer
         $this->sipe('publicDirectory', 'setPublic', $data, $team);
         $this->sipe('deletableDirectory', 'setDirDeletable', $data, $team);
         $this->sipe('restrictions.users', 'setMaxUsers', $data, $team);
+        $this->sipe('isUsingExistingRoles', 'setIsUsingExistingRoles', $data, $team);
 
         if (isset($data['directory'])) {
             /** @var ResourceNode $directoryNode */

--- a/src/main/community/Subscriber/Crud/TeamSubscriber.php
+++ b/src/main/community/Subscriber/Crud/TeamSubscriber.php
@@ -129,7 +129,6 @@ class TeamSubscriber implements EventSubscriberInterface
 
             $team->setRole($teamRole);
             $team->setManagerRole($teamManagerRole);
-
         } else {
             // Checks and creates role for team members & team manager if needed.
             $teamRole = $team->getRole();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no

### Added an option when creating a team to choose whether or not to use existing roles.

- Added of a Boolean field on the Team entity to store whether or not existing roles are used.
- Removal "delete cascade" on the role and managerRole relationships of  Team entity.
- Removal of the uniqueness constraint on the Team entity for role_id and manager_role_id.
- New field added to serializer and deserializer.
- Add new 'useExistingRoles' field in the form.
- Prevent roles from being created automatically when the team is created if useExistingRoles = true.
- Prevent team roles from being deleted when the team is deleted if they are existing roles.
