### PR TITLE
fixes initialization of workspace evaluations

### DIFF
--- a/src/main/evaluation/Subscriber/WorkspaceEvaluationSubscriber.php
+++ b/src/main/evaluation/Subscriber/WorkspaceEvaluationSubscriber.php
@@ -52,7 +52,7 @@ class WorkspaceEvaluationSubscriber implements EventSubscriberInterface
         MessageBusInterface $messageBus,
         ObjectManager $om,
         WorkspaceEvaluationManager $manager,
-        CertificateManager $certificateManager
+        CertificateManager $certificateManager,
     ) {
         $this->tokenStorage = $tokenStorage;
         $this->messageBus = $messageBus;

--- a/src/main/evaluation/Subscriber/WorkspaceEvaluationSubscriber.php
+++ b/src/main/evaluation/Subscriber/WorkspaceEvaluationSubscriber.php
@@ -101,6 +101,10 @@ class WorkspaceEvaluationSubscriber implements EventSubscriberInterface
     {
         $role = $event->getRole();
 
+        if (!$this->tokenStorage->getToken()->getUser() instanceof User) {
+            return;
+        }
+        
         // init evaluation for all the workspaces accessible by the role
         // this is not required by the code, but is a feature for managers to see users in evaluation tool/exports
         // event if they have not opened the workspace yet.

--- a/src/main/evaluation/Subscriber/WorkspaceEvaluationSubscriber.php
+++ b/src/main/evaluation/Subscriber/WorkspaceEvaluationSubscriber.php
@@ -104,7 +104,7 @@ class WorkspaceEvaluationSubscriber implements EventSubscriberInterface
         if (!$this->tokenStorage->getToken()->getUser() instanceof User) {
             return;
         }
-        
+
         // init evaluation for all the workspaces accessible by the role
         // this is not required by the code, but is a feature for managers to see users in evaluation tool/exports
         // event if they have not opened the workspace yet.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

When creating a new user, the token is not already filled, so the initialization fails.