### PR TITLE
[DevOps] updates php cs fixer config

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -10,6 +10,7 @@ return $config
         '@Symfony' => true,
         'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
         'array_syntax' => ['syntax' => 'short'],
-        'nullable_type_declaration_for_default_null_value' => false
+        'nullable_type_declaration_for_default_null_value' => false, // this is deprecated and will be treated as true
+        'trailing_comma_in_multiline' => ['elements' => ['array_destructuring', 'arrays', 'match']], // excludes func arguments and parameters
     ])
     ->setFinder($finder);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no

The `@Symfony` ruleset now forces trailing comas for multilines function arguments/parameters.

NB. I'm not against it, I just don't want to fix the entire code.