### PR TITLE
[Trainings] removes unsupported name/description search in events

### DIFF
--- a/src/plugin/cursus/Finder/EventType.php
+++ b/src/plugin/cursus/Finder/EventType.php
@@ -20,7 +20,7 @@ class EventType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => Event::class,
-            'fulltext' => ['name', 'code', 'description'],
+            'fulltext' => ['code'],
         ]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

